### PR TITLE
fix(workflows): stop auto-merge job from failing required check on benign errors

### DIFF
--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -149,19 +149,27 @@ jobs:
           fi
 
           # ── Gate 3: human_approved ─────────────────────────────────
+          # Trust GitHub's own reviewDecision instead of re-implementing the
+          # logic locally. GitHub already accounts for CODEOWNERS, dismissals,
+          # required_approving_review_count, etc. — and our previous local
+          # heuristic (just counting non-bot APPROVED reviews) could disagree
+          # with branch protection (e.g. on repos with require_code_owner_reviews=true),
+          # which led the script to attempt `gh pr merge --auto` on PRs that
+          # GitHub still considered REVIEW_REQUIRED and fail with
+          # "User is not authorized for this protected branch".
           HUMAN_APPROVALS=$(echo "$PR_JSON" | jq '
             [.reviews[]?
              | select(.state == "APPROVED")
              | select((.author.login // "") | endswith("[bot]") | not)
             ] | length')
-          if [ "$REVIEW_DECISION" = "CHANGES_REQUESTED" ] || [ "$HUMAN_APPROVALS" -lt 1 ]; then
-            HUMAN_APPROVED=false
-          else
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
             HUMAN_APPROVED=true
+          else
+            HUMAN_APPROVED=false
           fi
 
           echo "Gates: checks_passed=$CHECKS_PASSED up_to_date=$UP_TO_DATE human_approved=$HUMAN_APPROVED"
-          echo "       (checks_failed=$CHECKS_FAILED pending=$CHECKS_PENDING human_approvals=$HUMAN_APPROVALS)"
+          echo "       (checks_failed=$CHECKS_FAILED pending=$CHECKS_PENDING human_approvals=$HUMAN_APPROVALS reviewDecision=$REVIEW_DECISION)"
 
           # ── Label management ───────────────────────────────────────
           add_label() {
@@ -187,7 +195,15 @@ jobs:
             fi
 
             echo "All gates green — enabling auto-merge (squash)."
-            gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch
+            # IMPORTANT: enabling auto-merge can fail for many benign reasons
+            # (user not authorized to push to the protected branch, auto-merge
+            # not enabled in repo settings, PR not eligible, etc.). This
+            # workflow is a *required* status check, so a non-zero exit here
+            # would mark the check FAILED and block the PR forever — creating
+            # an approval/merge-retry loop. Treat the failure as advisory.
+            if ! gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash --delete-branch; then
+              echo "::warning::Could not enable auto-merge on PR #$PR_NUMBER. A maintainer with admin/bypass rights will need to merge it manually."
+            fi
           else
             remove_label "ready-for-auto-merge"
             echo "Not ready for auto-merge yet."


### PR DESCRIPTION
## Symptom

On PR #23, the *Auto-merge on Approval* required status check repeatedly went RED after every review/push, dragging the PR into a fix-and-re-review loop.

## Root cause

Two bugs in `.github/workflows/auto-merge-on-approval.yml`:

### Bug A — `gh pr merge --auto` failures crash the required check

The script calls `gh pr merge "$PR_NUMBER" --auto --squash --delete-branch` and runs under `set -euo pipefail`. Auto-merge enablement can fail for many benign reasons (user not authorized to push the protected branch, repo doesn't allow auto-merge for this PR, mismatched ref, etc.). Any such failure bubbles up as exit 1, marking the **required** status check FAIL — which blocks the PR.

This is exactly what was happening on PR #23:

```
All gates green — enabling auto-merge (squash).
GraphQL: Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
##[error]Process completed with exit code 1.
```

### Bug B — local "human approved" gate is more lenient than GitHub

The script counts any non-bot APPROVED review and ignores `reviewDecision`. Branch protection has `require_code_owner_reviews: true`, so an approval from someone who isn't a CODEOWNER does **not** flip GitHub's `reviewDecision` away from `REVIEW_REQUIRED`. The local script disagreed, marked `HUMAN_APPROVED=true`, and proceeded to step (A) — guaranteeing the failure.

## Fix

* Use GitHub's own `reviewDecision == "APPROVED"` as the gate. GitHub already accounts for CODEOWNERS, dismissals, required review counts, and last-push-approval.
* Wrap the `gh pr merge --auto` call in an `if ! …; then echo "::warning::…"; fi` block so a benign enablement failure becomes a workflow warning instead of a required-check failure.

## Verification

After this lands, on any future PR:

- If gates are green and auto-merge enablement succeeds → identical behaviour to today (PR auto-merges).
- If gates are green but auto-merge enablement fails (permissions, etc.) → workflow logs a warning, the required check still reports SUCCESS, and a maintainer can merge manually without a loop.
- If gates aren't actually green per GitHub (`reviewDecision != APPROVED`) → the script no longer attempts the doomed `gh pr merge` call in the first place.

PR #23's loop should not recur once this is in.
