### PR TITLE
chore: update .auto-registry/agent-registry.json (+1/-0 entries)

### DIFF
--- a/.auto-registry/agent-registry.json
+++ b/.auto-registry/agent-registry.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "generated_at": "2026-05-24T15:51:03Z",
+  "entries": [
+    {
+      "name": "openfoam",
+      "type": "agent",
+      "publisher_name": "Microsoft Discovery",
+      "path": "agents/openfoam",
+      "version": "1.0.0",
+      "associated_tools": [
+        "agents/openfoam/tools/openfoam"
+      ],
+      "foundry_tools": [],
+      "supported_regions": [],
+      "description": "Generalizable CFD agent powered by OpenFOAM. Infers simulation scenarios from natural language prompts, maps physical parameters, executes steady-state and transient solvers, and extracts quantitative metrics (drag, pressure drop, heat transfer, etc.) reported directly in chat. Supports internal flows, external aerodynamics, heat transfer, and rotating machinery via MRF.\n",
+      "tags": [
+        "computational-fluid-dynamics",
+        "openfoam",
+        "cfd",
+        "engineering",
+        "simulation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Automated registry refresh: the *Update Registry* workflow regenerated `.auto-registry/agent-registry.json` (1 entry: `openfoam`) on 2026-05-24 but its `gh pr create` call was rejected because **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** is currently OFF on this repo:

```GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)```n
The branch `chore/registry-refresh` already contains the correct generated file. Opening the PR manually from this account so the registry can finally land on `main`. Once the setting is re-enabled, future refreshes will open their own PRs as designed.