### PR TITLE
fix(openfoam): set publisher.name to 'Microsoft' for catalog consistency

### DIFF
--- a/agents/openfoam/metadata.yaml
+++ b/agents/openfoam/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/openfoam/tools/openfoam
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p


### PR DESCRIPTION
Other 1p agents under `agents/` use `Microsoft` as the `publisher.name`. `openfoam` was the only one using `Microsoft Discovery`. Aligning so Discovery Studio shows a consistent publisher label.