### PR TITLE
fix(metadata): standardise publisher.name to 'Microsoft' for all 1p agents

### DIFF
--- a/agents/boltztwo/metadata.yaml
+++ b/agents/boltztwo/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/boltztwo/tools/boltztwo
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/core-python-agent/metadata.yaml
+++ b/agents/core-python-agent/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/core-python-agent/tools/corepython
 publisher:
-  name: Microsoft Discovery Studio
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/janus/metadata.yaml
+++ b/agents/janus/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/janus/tools/janus
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/mattergen/metadata.yaml
+++ b/agents/mattergen/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/mattergen/tools/mattergen
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/openfoam/metadata.yaml
+++ b/agents/openfoam/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/openfoam/tools/openfoam
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/opensta/metadata.yaml
+++ b/agents/opensta/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/opensta/tools/opensta
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/rtl-ivlg-linter/metadata.yaml
+++ b/agents/rtl-ivlg-linter/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/rtl-ivlg-linter/tools/iverilog-tool
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/rtl-yosys-syn/metadata.yaml
+++ b/agents/rtl-yosys-syn/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/rtl-yosys-syn/tools/yosys
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p

--- a/agents/xyce/metadata.yaml
+++ b/agents/xyce/metadata.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 associated_tools:
   - agents/xyce/tools/xyce
 publisher:
-  name: Microsoft Discovery
+  name: Microsoft
   contact: discovery-catalog@microsoft.com
   support_url: https://github.com/microsoft/discovery/discussions/categories/bugs
   party: 1p


### PR DESCRIPTION
## Problem

Nine agents were using `Microsoft Discovery` or `Microsoft Discovery Studio` as `publisher.name` instead of the canonical `Microsoft` used by every other 1p agent in the catalog. Discovery Studio surfaces `publisher.name` directly, so this inconsistency shows up as mixed publisher labels in the agent list.

## Fix

Normalise `publisher.name` to `Microsoft` in the following `metadata.yaml` files:

- `agents/boltztwo`  (was: Microsoft Discovery)
- `agents/core-python-agent`  (was: Microsoft Discovery Studio)
- `agents/janus`  (was: Microsoft Discovery)
- `agents/mattergen`  (was: Microsoft Discovery)
- `agents/openfoam`  (was: Microsoft Discovery)
- `agents/opensta`  (was: Microsoft Discovery)
- `agents/rtl-ivlg-linter`  (was: Microsoft Discovery)
- `agents/rtl-yosys-syn`  (was: Microsoft Discovery)
- `agents/xyce`  (was: Microsoft Discovery)

All affected files still validate against `docs/schemas/metadata-schema.json`.

Supersedes #31 (which was a narrower fix for just openfoam).