### PR TITLE
Increase tunnel timeout

### DIFF
--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -208,7 +208,7 @@ def normalize_memory(memory: str | None) -> str | None:
 # ---------------------------------------------------------------------------
 
 _DEVICE_FLOW_POLL_INTERVAL = 5  # seconds between log checks
-_DEVICE_FLOW_POLL_TIMEOUT = 300  # give up after 5 minutes
+_DEVICE_FLOW_POLL_TIMEOUT = 1800  # give up after 30 minutes (jobs can queue for a while)
 
 
 _VALID_PROVIDERS = ("github", "microsoft")


### PR DESCRIPTION
## Summary

Some jobs have been slow to get resource and start up, meaning the CLI times out before the tunnel is established.  A longer-term fix (anytime attachment) is coming soon, but for now we are upping the total wait time from 5 to 30 minutes.

## Type of change

- [ ] New agent (under `agents/<name>/`)
- [ ] Update to an existing agent
- [ ] New starter kit (under `starter-kits/<name>/`)
- [ ] Update to an existing starter kit
- [ ] Schema change (`docs/schemas/**`)
- [ ] Workflow / script change (`.github/**`)
- [ ] Documentation only
- [x] Other (describe below)

## Related issue / tracking

n/a

## Schema impact

- [x] No schema changes
- [ ] Schema changes are backward compatible
- [ ] Schema changes are **breaking** — add the `breaking-change` label and link the rollout plan below

## Validation checklist

- [x] Documentation (`README.md`, schemas) is updated to match the change.
- [x] No hand-edits to `.auto-registry/**` (it is generated post-merge).
- [x] No OS / editor artefacts committed (`.DS_Store`, `.env`, `*.swp`, `.idea/`, `.vs/`, etc.).
- [x] If model-weight files are added, they are Git-LFS tracked, ≤5 GB each, and in an allowed format.
- [x] No secrets, customer data, or internal-only URLs are committed.
- [x] All Markdown links resolve.

## Reviewer notes (optional)

Considered adding more feedback / instructions to the UX, but not worth the additional risk / testing given the new debug implementation is coming in a few days.