### PR TITLE
Fix POL-010 false-positive on deleted artefact files

### DIFF
--- a/.github/scripts/validate_pr.py
+++ b/.github/scripts/validate_pr.py
@@ -655,7 +655,11 @@ def check_policy(repo: Path, folders: set[Path], changed_files: list[str]) -> li
     failures += check_model_weights(repo, changed_files)
 
     # POL-010: hidden / OS-artefact files are never allowed in any PR.
+    # Skip files that no longer exist in the PR checkout — those are deletions,
+    # and deleting a forbidden file is exactly the cleanup we want to allow.
     for f in changed_files:
+        if not (repo / f).exists():
+            continue
         name = Path(f).name
         rel_posix = f.replace("\\", "/")
         is_blocked = (

--- a/.github/tests/test_validate_pr_pol010.py
+++ b/.github/tests/test_validate_pr_pol010.py
@@ -1,0 +1,43 @@
+"""Tests for POL-010 inside validate_pr.py.
+
+POL-010 blocks committed OS / editor / env artefacts. It must NOT fire on
+*deletions* of those files — a PR that removes a forbidden file is exactly
+the cleanup we want to allow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from validate_pr import check_policy
+
+
+def _has_pol010(failures, file_path: str) -> bool:
+    return any(f.rule_id == "POL-010" and f.file == file_path for f in failures)
+
+
+def test_pol010_fires_when_env_file_is_added(tmp_path: Path) -> None:
+    env = tmp_path / "archive" / "foo" / ".env.example"
+    env.parent.mkdir(parents=True)
+    env.write_text("KEY=value\n", encoding="utf-8")
+
+    changed = ["archive/foo/.env.example"]
+    failures = check_policy(tmp_path, set(), changed)
+
+    assert _has_pol010(failures, "archive/foo/.env.example")
+
+
+def test_pol010_skips_deleted_env_file(tmp_path: Path) -> None:
+    # File appears in the changed list but does NOT exist in the PR checkout
+    # — i.e. the PR deletes it. POL-010 should not fire.
+    changed = ["archive/foo/.env.example"]
+    failures = check_policy(tmp_path, set(), changed)
+
+    assert not _has_pol010(failures, "archive/foo/.env.example")
+
+
+def test_pol010_skips_deleted_ds_store(tmp_path: Path) -> None:
+    changed = ["some/path/.DS_Store"]
+    failures = check_policy(tmp_path, set(), changed)
+
+    assert not _has_pol010(failures, "some/path/.DS_Store")


### PR DESCRIPTION
## Summary

Fixes a false-positive in the `Validate PR` check (POL-010) that blocks PRs which **delete** forbidden artefact files (`.env*`, `.DS_Store`, `.swp`, `.idea/**`, etc.).

### Repro

PR #48 deletes the `archive/` tree, which contained two `.env.example` files. The validator flagged them as policy violations even though the PR is removing them:

```
[POL-010] archive/6-solutions/common-infra/ANF-S3-MCP/server-s3mcp/config/.env.example
[POL-010] archive/utils/build-and-deploy-tool-agents/.env.example
```

This blocks merge despite a clean `MERGEABLE` / `APPROVED` state.

### Root cause

`check_policy` receives a flat `changed_files` list with no add/modify/delete status. POL-010 iterated over the list and matched names/paths without checking whether the file actually exists in the PR checkout.

### Fix

Skip changed paths that no longer exist in the PR checkout — those are deletions, and deleting a forbidden artefact is exactly the cleanup POL-010 is meant to encourage.

### Tests

New `.github/tests/test_validate_pr_pol010.py`:
- ✅ POL-010 fires when `.env.example` is **added**
- ✅ POL-010 skips when `.env.example` is **deleted**
- ✅ POL-010 skips when `.DS_Store` is **deleted**

Full suite: `42 passed`.

### Type of change

- [ ] New agent
- [ ] Update to an existing agent
- [ ] New starter kit
- [ ] Update to an existing starter kit
- [ ] Schema change
- [x] Workflow / script change (`.github/**`)
- [ ] Documentation only
- [ ] Other

### Related

Unblocks #48.