### PR TITLE
feat(cli): add 'discovery job debug' + Pods table for Running ops

### DIFF
--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
@@ -34,6 +34,7 @@ from .cli_build import (  # noqa: F401
 from .cli_build import app as build_app
 from .cli_cleanup import app as cleanup_app
 from .cli_configure import app as configure_app
+from .cli_debug import app as debug_app
 from .cli_doctor import app as doctor_app
 
 # Re-export helpers for backward compatibility with tests
@@ -48,6 +49,7 @@ from .cli_submit import app as submit_app
 # Re-export API functions for tests
 from .dataplane_api import (  # noqa: F401
     cancel_operation,
+    connect_debug_container,
     get_compute_status,
     get_operation_status,
     list_operations,
@@ -125,6 +127,7 @@ job_app.command(name="start")(submit_app.registered_commands[0].callback)
 job_app.command(name="batch")(submit_app.registered_commands[1].callback)
 job_app.command(name="vscode")(submit_app.registered_commands[2].callback)
 job_app.command(name="cancel")(submit_app.registered_commands[3].callback)
+job_app.command(name="debug")(debug_app.registered_commands[0].callback)
 job_app.command(name="running")(status_app.registered_commands[0].callback)
 job_app.command(name="pending")(status_app.registered_commands[1].callback)
 job_app.command(name="done")(status_app.registered_commands[2].callback)

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_debug.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_debug.py
@@ -1,0 +1,65 @@
+"""CLI command for starting a debug session on a running operation."""
+
+from __future__ import annotations
+
+import httpx
+import typer
+
+from discovery.common.logging import debug, error, info, success
+
+from .cli_helpers import emit_env, format_service_error, get_config_file_path, load_project_config
+from .dataplane_api import PollError, connect_debug_container
+
+app = typer.Typer()
+
+
+@app.command()
+def debug_command(
+    operation_id: str = typer.Argument(..., help="Operation ID of a running job to debug"),
+    pod: int = typer.Option(0, "--pod", "-p", help="Pod index to debug (0=leader/main, 1+=workers). Use 'job status' to see available pods."),
+) -> None:
+    """Start a debug session on a running operation.
+
+    Creates a Dev Tunnel on your behalf and attaches a VS Code debug container
+    to the running job. The tunnel appears in your VS Code Remote Tunnels list.
+
+    Example:
+        discovery job debug abc12345-def6-7890-abcd-ef1234567890
+        discovery job debug abc12345-def6-7890-abcd-ef1234567890 --pod 2
+    """
+    debug("debug_command(): entering")
+    env_cfg = load_project_config(get_config_file_path())
+    emit_env(env_cfg)
+
+    info(f"Starting debug session for operation {operation_id} (pod {pod})...")
+
+    try:
+        result = connect_debug_container(
+            project_name=env_cfg.project_name,
+            operation_id=operation_id,
+            workspace_url=env_cfg.workspace_url,
+            pod_index=pod,
+        )
+    except httpx.HTTPStatusError as exc:
+        error(format_service_error(exc))
+        raise typer.Exit(code=1) from exc
+    except httpx.TransportError as exc:
+        error(f"Network error (retries exhausted): {type(exc).__name__}: {exc}")
+        raise typer.Exit(code=1) from exc
+    except PollError as exc:
+        error(f"Failed to start debug session: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    tunnel_id = result.get("tunnelId", "unknown")
+    session_id = result.get("debugSessionId", "unknown")
+    status = result.get("status", "unknown")
+
+    success("Debug session created!")
+    info(f"  Tunnel ID:    {tunnel_id}")
+    info(f"  Session ID:   {session_id}")
+    info(f"  Status:       {status}")
+    info("")
+    info("Connect via VS Code:")
+    info(f"  1. Open VS Code")
+    info(f"  2. Go to Remote Explorer → Tunnels")
+    info(f'  3. Find "{tunnel_id}" and click Connect')

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_debug.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_debug.py
@@ -10,6 +10,7 @@ from discovery.common.logging import debug, error, info, success
 from .cli_helpers import emit_env, format_service_error, get_config_file_path, load_project_config
 from .dataplane_api import PollError, connect_debug_container
 
+
 app = typer.Typer()
 
 
@@ -51,15 +52,18 @@ def debug_command(
         raise typer.Exit(code=1) from exc
 
     tunnel_id = result.get("tunnelId", "unknown")
+    tunnel_name = result.get("tunnelName") or tunnel_id
     session_id = result.get("debugSessionId", "unknown")
     status = result.get("status", "unknown")
 
     success("Debug session created!")
+    info(f"  Tunnel name:  {tunnel_name}")
     info(f"  Tunnel ID:    {tunnel_id}")
     info(f"  Session ID:   {session_id}")
+    info(f"  Pod index:    {pod}")
     info(f"  Status:       {status}")
     info("")
     info("Connect via VS Code:")
-    info(f"  1. Open VS Code")
-    info(f"  2. Go to Remote Explorer → Tunnels")
-    info(f'  3. Find "{tunnel_id}" and click Connect')
+    info("  1. Open VS Code")
+    info("  2. Go to Remote Explorer → Tunnels")
+    info(f'  3. Find "{tunnel_name}" and click Connect')

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
@@ -25,7 +25,9 @@ from .cli_helpers import (
     render_error_with_details,
 )
 from .dataplane_api import (
+    OperationNotFoundError,
     get_compute_status,
+    get_operation_pods,
     get_operation_status,
     list_operations,
     list_operations_page,
@@ -462,6 +464,40 @@ def status_cmd(
             table.add_row(formatted_time, completed_time, runtime_str, result.status, runtime_details)
 
             console.print(table)
+
+            # Display pods table for Running operations (preview endpoint).
+            # Best-effort: silently skip on 404/transport errors so CLIs
+            # running against servers without the pods endpoint still work.
+            if result.status == AzureCoreOperationState.RUNNING:
+                try:
+                    pods = get_operation_pods(
+                        env_cfg.project_name,
+                        operation_id,
+                        env_cfg.workspace_url,
+                    )
+                except OperationNotFoundError as ex:
+                    debug(f"Pods endpoint returned 404 for {operation_id}: {ex}")
+                    pods = None
+                except Exception as ex:  # pragma: no cover - defensive
+                    debug(f"Failed to fetch pods for {operation_id}: {ex}")
+                    pods = None
+
+                if pods:
+                    pods_table = Table(
+                        title="Pods",
+                        show_header=True,
+                        header_style="bold cyan",
+                    )
+                    pods_table.add_column("Index", style="cyan", justify="right")
+                    pods_table.add_column("Role", style="magenta")
+                    pods_table.add_column("Phase", style="green")
+                    for pod in pods:
+                        pods_table.add_row(str(pod.index), pod.role, pod.phase)
+                    console.print(pods_table)
+                elif pods == []:
+                    console.print(
+                        "[dim]No pods reported yet for this running operation.[/dim]"
+                    )
 
             is_failed = result.status in ("Failed", "Canceled")
 

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
@@ -790,3 +790,45 @@ def _extract_tool_report_logs(data: ToolReport) -> list[str]:
     else:
         raw_lines = str(logs_field).splitlines()
     return [line for line in (entry.strip() for entry in raw_lines) if line]
+
+
+def connect_debug_container(
+    project_name: str,
+    operation_id: str,
+    workspace_url: str,
+    pod_index: int = 0,
+) -> dict[str, Any]:
+    """Start a debug session on a running operation.
+
+    Calls the :connect endpoint which auto-resolves the container name.
+    The service creates a Dev Tunnel on behalf of the user and provisions an
+    ephemeral debug container.
+
+    Args:
+        project_name: The project name
+        operation_id: The operation ID of a running tool execution
+        workspace_url: The workspace URL
+        pod_index: Pod index (0=leader/main, 1+=workers)
+
+    Returns:
+        Dict with tunnelId, tunnelName, debugSessionId, status, message, etc.
+    """
+    if not project_name or not operation_id:
+        msg = "project_name and operation_id required"
+        raise PollError(msg)
+    token = get_access_token()
+
+    pod_query = f"?pod={pod_index}" if pod_index != 0 else ""
+    url = (
+        f"{workspace_url.rstrip('/')}/tools/projects/{project_name}"
+        f"/operations/{operation_id}:connect{pod_query}"
+    )
+    debug(f"POST {url}")
+
+    with _create_client() as client:
+        resp = client.post(
+            url,
+            headers=AuthHeaders(Authorization=f"Bearer {token}").model_dump(),  # type: ignore
+        )
+    resp.raise_for_status()
+    return resp.json() if resp.content else {}

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
@@ -49,8 +49,10 @@ from discovery.poll.models.auth import AuthHeaders
 from discovery.poll.models.compute import ComputeUsageModel
 from discovery.poll.models.tool_response import (
     OperationsListResponse,
+    PodInfo,
     ToolExecutionResponse,
     ToolReport,
+    ToolRunPodsResponse,
 )
 from discovery.poll.models.tool_run import ToolRunRequest
 
@@ -832,3 +834,55 @@ def connect_debug_container(
         )
     resp.raise_for_status()
     return resp.json() if resp.content else {}
+
+
+class OperationNotFoundError(PollError):
+    """Raised when the pods preview endpoint returns 404 for an operation id."""
+
+
+def get_operation_pods(
+    project_name: str,
+    operation_id: str,
+    workspace_url: str,
+) -> list[PodInfo]:
+    """Fetch the pod list for a running tool execution (preview endpoint).
+
+    Calls ``GET /tools/projects/{project}/preview/operations/{operationId}/pods``.
+    Returns an empty list if the operation isn't Running or if the server
+    couldn't query the cluster. Raises :class:`OperationNotFoundError` if the
+    server returns 404 (unknown operation id). Other HTTP errors propagate as
+    :class:`httpx.HTTPStatusError`.
+
+    Args:
+        project_name: The project name
+        operation_id: The operation ID of the tool execution
+        workspace_url: The workspace URL
+
+    Returns:
+        List of :class:`PodInfo` entries, sorted leader/main first then workers.
+    """
+    if not project_name or not operation_id:
+        msg = "project_name and operation_id required"
+        raise PollError(msg)
+
+    token = get_access_token()
+    url = (
+        f"{workspace_url.rstrip('/')}/tools/projects/{project_name}"
+        f"/preview/operations/{operation_id}/pods"
+    )
+    debug(f"GET {url}")
+
+    with _create_client() as client:
+        resp = client.get(
+            url,
+            headers=AuthHeaders(Authorization=f"Bearer {token}").model_dump(),  # type: ignore
+        )
+
+    if resp.status_code == 404:
+        msg = f"Operation '{operation_id}' not found in project '{project_name}'"
+        raise OperationNotFoundError(msg)
+    resp.raise_for_status()
+
+    if not resp.content or not resp.content.strip():
+        return []
+    return ToolRunPodsResponse.model_validate(resp.json()).pods

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/tool_response.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/tool_response.py
@@ -61,7 +61,7 @@ class ToolResult(BaseModel):
     runtime_details: str = Field(..., alias="runtimeDetails")
     status: AzureCoreOperationState = Field(
         ..., description="Status of the tool execution at completion."
-    )  # noqa: E501
+    )
     tool_report: ToolReport = Field(..., alias="toolReport")
 
     model_config = ConfigDict(
@@ -129,6 +129,44 @@ class OperationsResultModel(BaseModel):
     )
 
 
+class PodInfo(BaseModel):
+    """Status information for a single pod in a running tool execution.
+
+    Returned by the preview pods endpoint
+    (GET /tools/projects/{project}/preview/operations/{operationId}/pods).
+    The ``index`` corresponds to the ``?pod=`` query parameter on the
+    ``:connect`` API.
+    """
+
+    index: int = Field(
+        ..., description="Linear pod index (0 = leader/main, 1+ = workers)."
+    )
+    role: str = Field(
+        ..., description='Pod role: "main" (single-container), "leader" or "worker" (MPI).'
+    )
+    phase: str = Field(
+        ..., description="Kubernetes pod phase: Running, Pending, Succeeded, Failed, Unknown."
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True,
+        serialize_by_alias=True,
+    )
+
+
+class ToolRunPodsResponse(BaseModel):
+    """Response model for the preview pods endpoint."""
+
+    pods: list[PodInfo] = Field(default_factory=list)
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        str_strip_whitespace=True,
+        serialize_by_alias=True,
+    )
+
+
 class OperationsListResponse(BaseModel):
     """Response model for listing operations."""
 
@@ -151,8 +189,10 @@ class OperationsListResponse(BaseModel):
 __all__ = [
     "OperationsListResponse",
     "OperationsResultModel",
+    "PodInfo",
     "ToolExecutionEnvelope",
     "ToolExecutionResponse",
     "ToolReport",
     "ToolResult",
+    "ToolRunPodsResponse",
 ]

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_debug.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_debug.py
@@ -1,0 +1,69 @@
+"""Tests for the `discovery job debug` command."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from discovery.poll.cli_debug import app
+
+
+def _env_cfg() -> MagicMock:
+    cfg = MagicMock()
+    cfg.project_name = "proj"
+    cfg.workspace_url = "https://ws"
+    return cfg
+
+
+@pytest.fixture
+def _stub_env():
+    with (
+        patch("discovery.poll.cli_debug.load_project_config", return_value=_env_cfg()),
+        patch("discovery.poll.cli_debug.get_config_file_path"),
+        patch("discovery.poll.cli_debug.emit_env"),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("_stub_env")
+def test_debug_banner_prefers_tunnel_name() -> None:
+    with patch("discovery.poll.cli_debug.connect_debug_container") as mock_connect:
+        mock_connect.return_value = {
+            "tunnelId": "debug-abc",
+            "tunnelName": "friendly-debug-name",
+            "debugSessionId": "sess-1",
+            "status": "Creating",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["op-123"])
+
+    assert result.exit_code == 0, result.output
+    assert "friendly-debug-name" in result.output
+    # The VS Code instruction line should point at the friendly name, not the id
+    assert 'Find "friendly-debug-name"' in result.output
+
+
+@pytest.mark.usefixtures("_stub_env")
+def test_debug_banner_falls_back_to_tunnel_id_when_name_missing() -> None:
+    captured: dict[str, Any] = {}
+
+    with patch("discovery.poll.cli_debug.connect_debug_container") as mock_connect:
+        mock_connect.return_value = {
+            "tunnelId": "debug-xyz",
+            # no tunnelName (older server)
+            "debugSessionId": "sess-2",
+            "status": "Creating",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["op-123", "--pod", "2"])
+        captured["kwargs"] = mock_connect.call_args.kwargs
+
+    assert result.exit_code == 0, result.output
+    assert 'Find "debug-xyz"' in result.output
+    assert "Pod index:    2" in result.output
+    assert captured["kwargs"]["pod_index"] == 2

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_status.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_status.py
@@ -444,3 +444,104 @@ class TestLargeWorkspacePagination:
         # Should show actionable guidance
         error_msg = mock_error.call_args[0][0]
         assert "--limit" in error_msg or "--pool" in error_msg
+
+# -------- Pods rendering in `discovery job status <id>` --------
+
+from typer.testing import CliRunner  # noqa: E402
+
+from discovery.poll.cli_status import app as status_app  # noqa: E402
+from discovery.poll.dataplane_api import OperationNotFoundError  # noqa: E402
+from discovery.poll.models.tool_response import (  # noqa: E402
+    AzureCoreOperationState,
+    PodInfo,
+)
+
+
+def _fake_op_status(status: str) -> MagicMock:
+    """Build a stub ToolExecutionResponse-like object for status_cmd."""
+    result = MagicMock()
+    result.created_at = datetime(2026, 3, 30, 0, 0, 0, tzinfo=timezone.utc)
+    result.completed_at = None
+    result.runtime_details = "runtime"
+    result.tool_report = None
+    result.debug_info = ""
+    result.output_data = []
+
+    op = MagicMock()
+    op.id = "op-xyz"
+    op.status = AzureCoreOperationState(status)
+    op.result = result
+    op.error = None
+    return op
+
+
+@pytest.fixture
+def _stub_status_env():
+    cfg = MagicMock(project_name="proj", workspace_url="https://ws")
+    with (
+        patch("discovery.poll.cli_status.load_project_config", return_value=cfg),
+        patch("discovery.poll.cli_status.get_config_file_path"),
+        patch("discovery.poll.cli_status.emit_env"),
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("_stub_status_env")
+def test_running_op_renders_pods_table() -> None:
+    with (
+        patch(
+            "discovery.poll.cli_status.get_operation_status",
+            return_value=_fake_op_status("Running"),
+        ),
+        patch(
+            "discovery.poll.cli_status.get_operation_pods",
+            return_value=[
+                PodInfo(index=0, role="leader", phase="Running"),
+                PodInfo(index=1, role="worker", phase="Pending"),
+            ],
+        ) as mock_get_pods,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(status_app, ["status", "op-xyz"])
+
+    assert result.exit_code == 0, result.output
+    assert mock_get_pods.called
+    assert "leader" in result.output
+    assert "worker" in result.output
+    assert "Pending" in result.output
+
+
+@pytest.mark.usefixtures("_stub_status_env")
+def test_non_running_op_does_not_query_pods() -> None:
+    with (
+        patch(
+            "discovery.poll.cli_status.get_operation_status",
+            return_value=_fake_op_status("Succeeded"),
+        ),
+        patch("discovery.poll.cli_status.get_operation_pods") as mock_get_pods,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(status_app, ["status", "op-xyz"])
+
+    assert result.exit_code == 0, result.output
+    mock_get_pods.assert_not_called()
+
+
+@pytest.mark.usefixtures("_stub_status_env")
+def test_pods_fetch_failure_does_not_break_status() -> None:
+    with (
+        patch(
+            "discovery.poll.cli_status.get_operation_status",
+            return_value=_fake_op_status("Running"),
+        ),
+        patch(
+            "discovery.poll.cli_status.get_operation_pods",
+            side_effect=OperationNotFoundError("not found"),
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(status_app, ["status", "op-xyz"])
+
+    assert result.exit_code == 0, result.output
+    # Status output is still produced (table title contains the op id)
+    assert "op-xyz" in result.output

--- a/utilities/supercomputer-cli/discovery/tests/test_poll_module.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_poll_module.py
@@ -480,3 +480,139 @@ class TestOperationsListDualKey:
         dumped = result.model_dump(by_alias=True)
         assert "values" in dumped
         assert "value" not in dumped
+# -------- connect_debug_container contract --------
+
+
+class _ConnectStubResponse:
+    def __init__(
+        self,
+        status_code: int = 200,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.headers = {"content-type": "application/json"}
+        body = json.dumps(payload or {})
+        self.text = body
+        self.content = body.encode("utf-8")
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            msg = "stub http error"
+            raise dataplane_api.httpx.HTTPStatusError(
+                msg, request=None, response=None  # type: ignore[arg-type]
+            )
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _install_connect_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response_payload: dict[str, Any] | None = None,
+    status_code: int = 200,
+    captured: dict[str, Any] | None = None,
+) -> None:
+    monkeypatch.setattr(
+        dataplane_api, "get_access_token", lambda scope=dataplane_api.DEFAULT_SCOPE: "tok"
+    )
+
+    class StubClient:
+        def __enter__(self) -> StubClient:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+            return None
+
+        def post(self, url: str, **kwargs: Any) -> _ConnectStubResponse:
+            if captured is not None:
+                captured["url"] = url
+                captured["kwargs"] = kwargs
+            return _ConnectStubResponse(status_code=status_code, payload=response_payload)
+
+        def get(self, url: str, **kwargs: Any) -> _ConnectStubResponse:
+            if captured is not None:
+                captured["url"] = url
+                captured["kwargs"] = kwargs
+            return _ConnectStubResponse(status_code=status_code, payload=response_payload)
+
+    monkeypatch.setattr(dataplane_api.httpx, "Client", lambda **kwargs: StubClient())
+
+
+def test_connect_debug_container_default_pod_omits_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_connect_stub(
+        monkeypatch,
+        response_payload={"tunnelId": "t1", "tunnelName": "name-1"},
+        captured=captured,
+    )
+
+    result = dataplane_api.connect_debug_container(
+        project_name="proj",
+        operation_id="op1",
+        workspace_url="https://ws",
+    )
+
+    assert captured["url"] == "https://ws/tools/projects/proj/operations/op1:connect"
+    # No JSON body
+    assert "content" not in captured["kwargs"]
+    assert "data" not in captured["kwargs"]
+    assert "json" not in captured["kwargs"]
+    # Bearer header
+    assert captured["kwargs"]["headers"]["Authorization"] == "Bearer tok"
+    assert result["tunnelName"] == "name-1"
+
+
+def test_connect_debug_container_nonzero_pod_adds_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_connect_stub(monkeypatch, response_payload={}, captured=captured)
+
+    dataplane_api.connect_debug_container(
+        project_name="proj",
+        operation_id="op1",
+        workspace_url="https://ws/",
+        pod_index=3,
+    )
+
+    assert captured["url"] == "https://ws/tools/projects/proj/operations/op1:connect?pod=3"
+
+
+# -------- get_operation_pods contract --------
+
+
+def test_get_operation_pods_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    payload = {
+        "pods": [
+            {"index": 0, "role": "leader", "phase": "Running"},
+            {"index": 1, "role": "worker", "phase": "Pending"},
+        ]
+    }
+    _install_connect_stub(monkeypatch, response_payload=payload, captured=captured)
+
+    pods = dataplane_api.get_operation_pods("proj", "op1", "https://ws")
+
+    assert captured["url"] == "https://ws/tools/projects/proj/preview/operations/op1/pods"
+    assert captured["kwargs"]["headers"]["Authorization"] == "Bearer tok"
+    assert [p.index for p in pods] == [0, 1]
+    assert pods[0].role == "leader"
+    assert pods[1].phase == "Pending"
+
+
+def test_get_operation_pods_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_connect_stub(monkeypatch, response_payload={"pods": []})
+    assert dataplane_api.get_operation_pods("proj", "op1", "https://ws") == []
+
+
+def test_get_operation_pods_404_raises_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_connect_stub(monkeypatch, response_payload={}, status_code=404)
+    with pytest.raises(dataplane_api.OperationNotFoundError):
+        dataplane_api.get_operation_pods("proj", "op1", "https://ws")


### PR DESCRIPTION
## Summary

Adds a `discovery job debug <opId>` command that opens a VS Code debug session against a running tool run via the server-side OBO (On-Behalf-Of) Dev Tunnels flow.

Pairs with the data-plane `POST .../operations/{opId}:connect[?pod=N]` endpoint (data-plane PR microsoft `science-supercomputer#481519`) which has been validated live against `uksouth.stamp3` — see the end-to-end run below.

## What this PR adds

### `discovery job debug <opId>` (new command)
- Lives in `utilities/supercomputer-cli/discovery/src/discovery/poll/cli_debug.py`
- Hits the simplified `:connect` endpoint, prints the returned `tunnelName` (with `tunnelId` fallback for older servers), and tells the user to attach via VS Code → Remote Explorer → Tunnels.
- `--pod / -p <index>` selects which pod to debug (0 = leader/main, 1+ = workers). Default 0.
- New `connect_debug_container()` helper in `dataplane_api.py` (URL: `POST .../operations/{opId}:connect[?pod=N]`, Bearer auth, no body).

### `discovery job status <opId>` — Pods table for Running ops
- For operations in `Running` state, `status` now fetches and renders a per-pod table showing `index`, `role` (leader/worker), `phase` (Running/Pending/…).
- New `get_operation_pods()` helper hits `GET .../preview/operations/{opId}/pods` and parses `{ pods: [{ index, role, phase }] }`.
- 404 / transport errors when fetching pods are swallowed at debug level so the CLI keeps working against servers that haven't deployed the preview-pods PR yet.

### Models
- `PodInfo` and `ToolRunPodsResponse` added to `models/tool_response.py`.

### Tests (covered the 5 most relevant areas; 56 pass)
- `tests/test_cli_debug.py` — debug banner uses `tunnelName` when present, falls back to `tunnelId`, echoes pod index.
- `tests/test_cli_status.py` — `status` renders Pods table when Running, skips pod fetch when not Running, swallows fetch failures.
- `tests/test_poll_module.py` — `connect_debug_container()` URL/Bearer/`?pod=N` contract; `get_operation_pods()` URL/Bearer/parsing/404 contract.

(7 pre-existing test errors in `tests/test_poll_module.py` are due to a missing `tests/artifacts/` directory on `main` — unrelated to this PR.)

## End-to-end validation

Deployed `users/matthchan/devtunnels-obo-v2` (the matching data-plane branch) to `uksouth.stamp3` via the Discovery-Unified-Build + Discovery-Unified-Release pipelines, then exercised this CLI on the live SC:

```
$ discovery job start "sleep 3600" --no-wait --cpus 2 --memory 4Gi --image mcr.microsoft.com/azurelinux/base/core:3.0
[10:28:48] INF Job submitted. Operation ID: 31c118c515dc4bcfa752de2a97d5feb9

$ discovery job debug 31c118c515dc4bcfa752de2a97d5feb9
[10:32:37] INF Starting debug session for operation 31c118c5... (pod 0)...
[10:32:41] SUC Debug session created!
[10:32:41] INF   Tunnel name:  tidy-lake-sqt8w19
[10:32:41] INF   Tunnel ID:    tidy-lake-sqt8w19
[10:32:41] INF   Session ID:   ff79c676-07bb-4103-bb60-effcedb1ac49
[10:32:41] INF   Pod index:    0
[10:32:41] INF   Status:       Provisioning
[10:32:41] INF Connect via VS Code:
[10:32:41] INF   1. Open VS Code
[10:32:41] INF   2. Go to Remote Explorer → Tunnels
[10:32:41] INF   3. Find "tidy-lake-sqt8w19" and click Connect
```

End-to-end **4 seconds** from `discovery job debug` to a tunnel ready to attach.

## Rebase notes

- Original branch (`users/matthchan/cli-debug-command` in the old `microsoft/aifsp` tree) was forked at `bd3e14c` and lived at `utils/supercomputer-cli/`.
- This PR rebases the 2 author commits onto `microsoft/discovery@d07cbd1` (current `main`), translating paths from `utils/` → `utilities/`.
- Two trivial union-merge conflicts resolved in tests (`test_cli_status.py`, `test_poll_module.py`) where main added unrelated test classes (`TestFormatDuration`, `TestLargeWorkspacePagination`, `TestOperationsListDualKey`) — kept both halves.
- One import conflict in `cli.py` (main added `cli_doctor` + `cli_cleanup` imports near where this PR adds `cli_debug`) — kept all three.
