### PR TITLE
discovery-toolbox: ship v1.1.2

### DIFF
--- a/utilities/discovery-toolbox/About.md
+++ b/utilities/discovery-toolbox/About.md
@@ -1,0 +1,175 @@
+
+<div align="center">
+
+# Discovery Toolbox
+
+### Your Command Center for the Microsoft Discovery Platform
+
+*Discovery Toolbox provides an end‑to‑end deployment and management experience for the Microsoft Discovery platform — including instantiation of agents, tools, models, and (soon) knowledge bases, plus declarative validation plans and live agent chat — empowering teams to start doing agentic‑driven, scientific R&D from day one.*
+
+<sub>About for **v1.1.2** · [Send feedback](https://github.com/microsoft/discovery/issues/new?title=%5BFeedback%5D%20&labels=feedback)</sub>
+
+---
+
+</div>
+
+💡 **First‑time user?** Open the **Onboarding Journey** for a guided 6‑step path from initial Discovery to full deployment — or work through each sidebar section in order, from Prerequisites through Deployment to Operations, to understand what Microsoft Discovery needs and why.
+
+---
+
+## Requirements
+
+**Required**
+- **VS Code 1.95+**
+- **Azure subscription** with Microsoft Discovery enabled (provisioned by your Microsoft account team)
+- **Azure CLI** signed in (`az login`) — or VS Code Microsoft authentication
+
+**Optional**
+- **GitHub Copilot Chat** — enables the `@discovery` chat participant and `#discovery_*` language model tools for natural-language agent creation, catalog Q&A, and doc search. *Free tier works; Pro/Business removes monthly limits.*
+- **GitHub account with access to the `discovery-catalog` repo** — required only if you want to browse / deploy from the shared Discovery agent catalog.
+
+> Toolbox's deployment, inventory, cost, and operations features all work **without** GitHub Copilot. Only the chat surface depends on it.
+
+---
+
+## Discovery Toolbox Features
+
+<table>
+<tr>
+<td width="50%">
+
+### 🔧 End‑to‑End Deployment
+Provision the full Microsoft Discovery platform from scratch — VNets, supercomputers, workspaces, projects, chat models, storage, and managed identities — using a **bundled, hardened Bicep template** with network isolation tags, deployed directly from inside VS Code with live terminal output.
+
+</td>
+<td width="50%">
+
+### 🤖 Agent & Tool Publishing
+Publish AI agents and containerized tools directly to your Discovery environment. Create agents from scratch or from the catalog — configure model, instructions, tool bindings, and knowledge bases. Build tool images **remotely via ACR Tasks** and push them straight to your Azure Container Registry.
+
+</td>
+</tr>
+<tr>
+<td>
+
+### 🛡️ Prerequisite Validation
+Automatically verify 100+ Azure prerequisites — RBAC roles, resource providers, quotas, policies, **network security perimeter**, and configuration — before deployment, with one‑click remediation actions for every issue found.
+
+</td>
+<td>
+
+### 📊 Architecture Visualization
+See your entire Discovery deployment topology as an interactive diagram — workspaces, projects, agents, supercomputers, storage, networking — with real‑time health status. Export as PNG (2×) or SVG, or browse a built‑in example dataset.
+
+</td>
+</tr>
+<tr>
+<td>
+
+### 💰 Cost Analysis
+Track per‑resource costs across your Discovery resource groups — daily, weekly, and monthly breakdowns. Sortable table with RG and service filters, plus direct links to the Azure Portal cost blade.
+
+</td>
+<td>
+
+### 📋 Operational Monitoring
+5‑signal diagnostics dashboard — Resource Health, Active Alerts, Advisor Recommendations, Service Health, and Diagnostic Settings — across main and managed resource groups with KPI tiles.
+
+</td>
+</tr>
+<tr>
+<td>
+
+### ✅ Plan‑Driven Validation
+Author a declarative 7‑stage build plan (workspace → chat model → storage → project → agents → interactions), execute it, and review per‑step pass/fail with a JSONL audit footer. Stage 6 supports a multi‑substep composer — `createInvestigation`, `addTask`, `addConversation`, `addMessage` — so a single plan can stand up a project, deploy agents, and assert on chat responses end‑to‑end.
+
+</td>
+<td>
+
+### 💬 Live Agent Chat
+Talk to deployed Discovery agents from the **Validation Interactions** page — a 3‑pane chat UX (investigations rail · conversation switcher · message timeline) over the Discovery data plane. Four‑mode transport selector (`rest-only` / `mcp-only` / `rest-then-mcp` / `mcp-then-rest`) routes each message through REST `POST /conversations/{conv}/openai/responses` or MCP `notifications/message`, with conversation JSONL persistence under `~/.md-toolbox/conversations/`.
+
+</td>
+</tr>
+</table>
+
+---
+
+## Key Capabilities
+
+| Capability | Description |
+|---|---|
+| **Onboarding Journey** | Guided 6‑step path (Discover → Evaluate → Engage → Triage → Onboard → Deploy & Build) with curated links to the Azure announcement, MS Learn docs, solutions page, and registration form |
+| **Dashboard** | At‑a‑glance health of every section with colored status tiles, KPI/hybrid metric tiles, and completion tracking |
+| **Prerequisites** | Azure CLI, Bicep, login, tenant, subscription, region — including **approved‑region validation against the Azure locations API** |
+| **Deployment Settings** | Region + resource group selectors that act as both the **deployment target** for new infrastructure and the **management scope** the rest of the toolbox uses to discover existing deployments |
+| **Bicep Settings** | Separate sidebar entry for resource names, networking, node pool, chat model, and storage — split from Deployment Settings so deployment scope and template parameters are independently editable |
+| **Permission Auditing** | Enumerate **15 RBAC roles** (Owner, User Access Admin, Discovery Platform Admin/Contributor/Reader, Managed Identity Contributor/Operator, Storage Account/Blob Data Contributor, Network Contributor, AcrPush, Azure AI User/Owner, Reader, Bookshelf Index Data Reader) with member resolution (users, groups, service principals, managed identities) across subscription, RG, and child‑resource scopes — uses VS Code Graph token with `az cli` fallback |
+| **Role Summary** | **3‑persona** capability matrix (Platform Admin · Scientist · Reader, mutually exclusive top‑down) showing what each persona can and can't do based on current role assignments; collapsed by default with Expand all / Collapse all controls; Members footer row counting distinct users per persona |
+| **Assignments** | Sister page to Permissions — read‑only RBAC enumeration with member‑detail browsing |
+| **Network Security** | 4 checks for the AIFSPInfrastructure service principal: SP existence, NSP Perimeter Joiner custom role, role assignment, and Reader at subscription scope — with one‑click create/assign actions |
+| **Quota Management** | vCPU and AI Foundry TPM quotas per region with bar charts and one‑click quota‑form data generation; NetApp Files (optional storage backend) reported informationally |
+| **Resource Providers** | 20 Discovery‑relevant providers with Discovery‑specific descriptions and "Register All" |
+| **Azure Policy** | Detect Deny policies and compliance issues that could block Discovery resource deployment |
+| **Bicep Deployment** | Validate, configure, and deploy the bundled Bicep template with real‑time terminal output and an Infra Status bar showing live control‑plane resource state. The deploy gate is intentionally targeted — prerequisites, deployment settings, initial checks, and quota must pass plus the Owner‑or‑7‑roles rule (resource providers register during deployment, so they're not a prereq) |
+| **Agents Page** | Combined catalog browser + agent inventory — enumerate deployed agents across workspaces and projects with model, tools, KBs, and Studio/Foundry links; load tool/agent definitions from the discovery‑catalog (`registry.json`) with Docker, CPU, RAM, GPU columns |
+| **Tool Publishing** | End‑to‑end ACR build & push pipeline — remote builds via **ACR Tasks** (no local Docker required) — with image verification and ARM deploy; auto‑builds the per‑tool image during agent deploy when missing |
+| **Agent Publishing** | Create agents from scratch or catalog — select project, model, attach tools and knowledge bases; **8‑phase deploy progress events** with retry on failure |
+| **Data Plane Resources** | Discover agents, workflow agents, and investigations via the Discovery data‑plane API |
+| **Architecture Export** | Export your deployment topology as PNG (2×) or SVG; Show Example mode with realistic sample data |
+| **Tracking Log** | Azure Activity Log viewer with date range presets, search, sort, and expandable detail rows |
+| **Cost Analysis** | Per‑RG cost queries with daily/weekly/monthly breakdowns, RG and service filters |
+| **Diagnostics** | 5 signals with 6 KPI tiles and 5 collapsible data tables across main + managed RGs |
+| **Documentation** | Embedded MS Learn docs browser (no git clone required) |
+| **Activity Log** | Every Azure API call routed through `loggedFetch` for full traceability and troubleshooting |
+| **Validation Plans** | Declarative 7‑stage build pipeline (workspace · chat model · storage account · storage container · project · agents · interactions) authored on the **Validation Setup** page. Stage 6 supports a multi‑substep composer with five kinds — `createInvestigation` · `addTask` · `addConversation` · `addMessage` · legacy `interaction` — each fanning out to its own wire step, replayed by the **Validation Execution** page and surfaced on **Validation Results** with per‑step pass / fail and run JSONL footers |
+| **Validation Interactions** | Live chat with deployed Discovery agents from a dedicated page — investigations rail · conversation switcher · streaming message timeline. Backed by REST `POST /conversations/{conv}/openai/responses` (OpenAI Responses surface with Discovery `agent_reference` / `storageAssets` / `confirmations` extensions) and MCP `notifications/message` text deltas. All conversations persist as JSONL under `~/.md-toolbox/conversations/<name>.jsonl` |
+| **Chat Transport Modes** | Four‑mode selector (`rest-only` · `mcp-only` · `rest-then-mcp` · `mcp-then-rest`, default `rest-then-mcp`) decides which chat path is tried first and whether the other is a fallback. Workspace‑persisted on the Interactions page top bar, with per‑message override on Stage‑6 `addMessage` validation substeps. Each delivered message is tagged with a transport badge so failures are loud, not hidden |
+| **Update Checker** | Automatic version check on startup — banner on welcome page + VS Code notification when a new version is available. The checker polls `latest.json` in this folder's `vsix/` subfolder |
+
+---
+
+## Sections Overview
+
+| Group | Sections |
+|---|---|
+| **Introduction** | Welcome · About · Onboarding Journey · Workflow · Dashboard |
+| **Setup** | Prerequisites · Deployment Settings · Permissions · Assignments · Role Summary · Initial Checks · Network Security · Resource Providers · Quotas · Azure Policy |
+| **Deployment** | Bicep Settings · Control Plane Resources · Bicep Deployment · Data Plane Resources · Architecture |
+| **Operations** | Agents Catalog · Agent Deployment · Models · Cost Analysis · Diagnostics · Cleanup · MCP Catalog · MCP Invoke · Documentation · References |
+| **Validation** | Validation Setup · Validation Execution · Validation Results · Validation Interactions |
+| **Monitoring** | Tracking Log · Activity Log |
+
+> The standalone Tools page was merged into Agents in v0.7.85; tool catalog browsing and tool publishing now live on the unified **Agents Catalog** + **Agent Deployment** pages. The Validation group was introduced in v0.12.48 alongside the four new chat / investigation services.
+
+---
+
+## Upcoming Features
+
+| Feature | Description |
+|---|---|
+| 📚 **Bookshelves & Knowledge Bases** | Bookshelf enumeration, KB management, and data‑ingestion tracking — wired into the Agent Deploy form's Knowledge Bases multi‑select and the architecture diagram |
+| ✅ **Post‑Deploy Health Smoke** | Dashboard‑level health verification, endpoint connectivity tests, and Service Health correlation. Distinct from the shipped **Validation** feature (which runs a declarative plan and asserts each stage); this is a passive, always‑on health view |
+| 🧹 **Resource Deletion** | Delete actions for agents, tools, storage containers, and projects with confirmation and optional cascade |
+| 🟦 **Sidebar Status Indicators** | Activity Bar badge with failed‑check count plus per‑section status icons in the tree |
+| 🧪 **Centralized Input Validation** | Shared `validationRules.json` driving inline validation across every editable field |
+| 📦 **Standalone Resource Provisioning** | Install workspaces, projects, and other components via the Discovery REST API for granular, per‑resource control |
+| 💬 **@discovery Chat — write tools & bundled skills** | Phase 5+ follow‑on to the shipped chat participant. Adds write tools (deploy / configure) callable from chat, and bundled skill files for common workflows |
+
+---
+
+## Resources
+
+| | |
+|---|---|
+| ⬇️ **Download** | [`vsix/` folder](https://github.com/microsoft/discovery/tree/main/utilities/discovery-toolbox/vsix) — pick the file with the highest version number |
+| 🛠 **Install guide** | [README.md](./README.md#install) |
+| 🔒 **Privacy & data handling** | [PRIVACY.md](./PRIVACY.md) |
+| 📖 **Microsoft Learn Docs** | [learn.microsoft.com/en-us/azure/microsoft-discovery](https://learn.microsoft.com/en-us/azure/microsoft-discovery/) |
+| 📰 **Azure Blog Announcement** | [Microsoft Discovery: advancing agentic R&D at scale](https://azure.microsoft.com/en-us/blog/microsoft-discovery-advancing-agentic-rd-at-scale/) |
+| 🌐 **Azure Solutions Page** | [azure.microsoft.com/en-us/solutions/discovery](https://azure.microsoft.com/en-us/solutions/discovery) |
+| 💬 **Send Feedback** | [Open a GitHub Issue](https://github.com/microsoft/discovery/issues/new?title=%5BFeedback%5D%20&labels=feedback) |
+
+---
+
+<sub>About for Discovery Toolbox **v1.1.2** · built from `8155eb4` on 2026-05-29T17:58:52.454Z.</sub>

--- a/utilities/discovery-toolbox/PRIVACY.md
+++ b/utilities/discovery-toolbox/PRIVACY.md
@@ -1,0 +1,189 @@
+# Privacy
+
+The Microsoft Discovery Toolbox (this VS Code extension) is built to manage
+**your own** Azure resources. It runs entirely inside VS Code on your machine
+and talks to Azure on your behalf using credentials you've already signed in
+with. This document describes — concretely — what data the extension handles,
+where it goes, what it writes to disk, and how to remove it.
+
+> **TL;DR**
+>
+> - **No telemetry.** The extension does not send any usage data, error
+>   reports, or analytics anywhere.
+> - **No third-party data brokers.** All network calls go to Azure (your
+>   subscription), Microsoft Graph (your identity), GitHub (the public
+>   Discovery catalog + docs), or your own deployed Discovery workspace.
+> - **Local artifacts.** The extension writes JSONL logs of validation runs,
+>   conversations, scorecard runs, and agent deploys under `~/.md-toolbox/`.
+>   These contain workspace metadata and, for conversations + scorecards,
+>   the full text of prompts and responses you exchanged with agents. They
+>   never leave your machine and you can delete them at any time.
+> - **No persistent credentials.** Azure and GitHub access tokens are
+>   acquired through VS Code's built-in authentication providers, held in
+>   memory, and discarded; they are never written to any file the extension
+>   controls.
+
+---
+
+## 1. Telemetry and analytics
+
+**The extension collects no telemetry.** There are no calls to
+`vscode.telemetry`, Application Insights, `TelemetryReporter`, Google
+Analytics, or any other analytics endpoint. There is no opt-out toggle
+because there is nothing to opt out of.
+
+VS Code itself collects telemetry independently of this extension — see
+[VS Code telemetry settings](https://code.visualstudio.com/docs/getstarted/telemetry).
+
+## 2. Identity and authentication
+
+The extension uses VS Code's built-in authentication providers:
+
+| Provider | Used for | Token lifetime |
+|---|---|---|
+| `microsoft` | All Azure ARM and Discovery data-plane calls | ~1 hour, auto-refreshed by VS Code |
+| `github` | Reading the public [`microsoft/discovery-catalog`](https://github.com/microsoft/discovery-catalog) repository | Per your VS Code GitHub sign-in |
+
+**Tokens are never written to disk by this extension.** They are obtained
+on demand from VS Code's secure credential store, held in memory only for
+the duration of an outbound HTTP request, and discarded. The in-memory
+activity log explicitly excludes `Authorization` headers and never stores
+raw bearer tokens.
+
+The extension queries Microsoft Graph once per session to resolve the
+signed-in user's display name (shown in the welcome banner). No other
+identity data is retrieved.
+
+## 3. Network endpoints
+
+Every host the extension may contact, and what for:
+
+| Host | Purpose | Auth |
+|---|---|---|
+| `management.azure.com` | Azure Resource Manager — list/read/create/delete resources in **your** subscription | Microsoft session token |
+| `graph.microsoft.com` | Resolve your display name; verify the `AIFSPInfrastructure` service principal exists in your tenant (network-hardened workspaces only) | Microsoft session token |
+| `*.azurecr.io` | Pull/push container images to **your** Azure Container Registry | ACR credentials sourced from ARM |
+| `<workspace>.<region>.api.discovery.microsoft.com` (and similar) | Discovery workspace data plane — investigations, agents, conversations | Microsoft session token |
+| `mcp.discovery.azure.com` (when MCP enabled) | Discovery MCP server for tool invocation | Microsoft session token |
+| `learn.microsoft.com` | Open documentation links in your browser (no fetch from the extension) | None |
+| `raw.githubusercontent.com/MicrosoftDocs/azure-docs/...` | Fetch Microsoft Discovery documentation pages for the in-extension Docs view | Anonymous HTTP GET |
+| `api.github.com` / `raw.githubusercontent.com/microsoft/discovery-catalog` | Fetch the Discovery catalog (tool + agent definitions) | Your GitHub session token if you're signed in; anonymous (rate-limited) otherwise |
+| `api.github.com/repos/microsoft/discovery/contents/utilities/discovery-toolbox/...` | Fetch the toolbox update manifest + new VSIX from the release folder | Your GitHub session token while the repo is private; anonymous once it goes public |
+
+The extension does not contact any other host. It does not send error
+reports, crash dumps, or "phone home" to any Microsoft or third-party
+service.
+
+## 4. Local files
+
+The extension writes to two locations on your machine. Both are
+user-purgeable: delete the directory and the data is gone.
+
+### `~/.md-toolbox/`
+
+Default location: `%USERPROFILE%\.md-toolbox\` (Windows),
+`~/.md-toolbox/` (macOS / Linux).
+
+| Subfolder | Contents |
+|---|---|
+| `deploys/*.jsonl` | One file per agent deploy. Stage logs (image build, ARM PUT, agent upsert), timings, resource IDs. Does **not** contain prompts. |
+| `conversations/*.jsonl` | One file per conversation thread you've held with a deployed agent. **Includes the full text of every prompt you sent and every response the agent returned.** Includes workspace ARM id, project, investigation, conversation, and agent names. |
+| `agent-scorecards/*.jsonl` | One file per scorecard run. **Includes the full prompt sent to each agent, the full response, the LLM judge's rationale, and the judge's confidence bucket.** Includes workspace ARM id, project, and agent names. |
+| `validations/*.jsonl` | One file per validation run. Stage outcomes, timings, resource IDs, error messages. Does **not** contain prompts or agent responses. |
+| `.cache/discovery-catalog/` | Cached copy of the public `microsoft/discovery-catalog` repository for offline use. |
+
+You can delete any subfolder (or the whole `~/.md-toolbox/` directory) at
+any time. The extension will recreate empty subfolders the next time the
+relevant feature runs.
+
+### OS temp directory
+
+The extension stages Bicep parameter files and container build contexts
+under your OS temp directory (`%TEMP%` / `/tmp`) for the duration of a
+deploy. These are cleaned up by the OS automatically.
+
+### VS Code workspace storage
+
+Some user-interface preferences (drawer widths, dashboard layout) are
+saved to VS Code's `localStorage`. No customer data is stored there.
+
+## 5. AI calls (LLM judge in Agent Scorecard)
+
+The **Agent Scorecard** feature uses an LLM to score the responses your
+deployed agents return to a sample prompt. The judging call is made
+through VS Code's built-in language-model API:
+`vscode.lm.selectChatModels({ vendor: 'copilot' })`.
+
+In practice this means: **the prompt you sent to each agent, plus the
+response that agent returned, is forwarded to GitHub Copilot using your
+own Copilot subscription / license**, so that Copilot can return a score
+and rationale. The extension itself does not call any Azure OpenAI
+endpoint directly for judging — it delegates to whichever model your
+Copilot subscription resolves to.
+
+If you do not want this data sent to Copilot, do not run the Agent
+Scorecard feature.
+
+All other AI interactions (conversations on the Validation Interactions
+page, MCP tool invocations) go **only** to the Discovery workspace you
+deployed yourself, in your subscription, in your chosen Azure region.
+
+## 6. Activity log
+
+The "Activity Log" view shows the most recent ~500 HTTP requests and
+actions the extension has performed in the current session. It is
+in-memory only and is cleared when you reload the window. It is never
+written to disk and never sent off the machine.
+
+## 7. Personal data we never collect
+
+To make this explicit: this extension does not collect, transmit, or
+store:
+
+- Your name, email, phone, address, or any contact information beyond
+  the display name VS Code's auth provider already gives us
+- Your IP address (the extension makes no calls that go to anything we
+  control)
+- Browser fingerprints, screen dimensions, OS version, or any device
+  fingerprint
+- Source code, file contents, or anything from your other VS Code
+  workspaces
+- Keystrokes outside the prompts you deliberately send to deployed
+  agents (and even those stay in `~/.md-toolbox/conversations/` on your
+  own machine)
+
+## 8. How to remove all extension data
+
+```bash
+# All local artifacts (validation runs, conversations, scorecards, deploys, cache):
+rm -rf ~/.md-toolbox
+
+# VS Code-managed preferences (drawer widths etc.):
+# Use VS Code's Command Palette: "Developer: Reload Window" then
+# "Settings: Clear All" — or manually delete the extension's entry
+# under your VS Code globalStorage path.
+
+# Azure resources created by deploys:
+# Use the Inventory → Tear down… action, or delete the resource group
+# in the Azure portal.
+```
+
+## 9. Reporting privacy concerns
+
+If you spot a behavior of this extension that contradicts anything in
+this document, please open an issue on the public release repository
+at [`microsoft/discovery`](https://github.com/microsoft/discovery/issues/new?labels=feedback&title=%5BPrivacy%5D%20)
+or contact the maintainers.
+
+The "Send Feedback" entry in the Discovery Toolbox sidebar is hidden
+by default to keep the surface minimal. Set `mdToolbox.showFeedback`
+to `true` in VS Code Settings if you want a one-click pre-filled
+issue form that includes your current toolbox version, active page,
+tenant id, subscription id, region, and resource group. Review the
+pre-filled body before submitting — the GitHub issue is public.
+
+---
+
+<sub>Privacy notice for Discovery Toolbox **v1.1.2** · built from `8155eb4` on 2026-05-29T17:58:52.454Z.</sub>
+
+<sub>This document is maintained in the open in the [`microsoft/discovery`](https://github.com/microsoft/discovery/tree/main/utilities/discovery-toolbox) repository. It covers only this extension; for VS Code's own privacy practices see the [VS Code privacy statement](https://code.visualstudio.com/license).</sub>

--- a/utilities/discovery-toolbox/README.md
+++ b/utilities/discovery-toolbox/README.md
@@ -1,0 +1,86 @@
+# Discovery Toolbox
+
+> Your command center for [Microsoft Discovery](https://learn.microsoft.com/en-us/azure/microsoft-discovery/) — an IT DevOps–focused VS Code extension for the setup, management, and operation of the Azure infrastructure required to run the platform.
+
+Microsoft Discovery is the AI for Science platform that enables agentic-driven scientific research and development. Discovery Toolbox provides an end-to-end deployment and management experience — including instantiation of agents, tools, models, and (soon) knowledge bases, plus declarative validation plans and live agent chat — empowering teams to start doing agentic-driven, scientific R&D from day one.
+
+**Current version:** `v1.1.2`
+
+---
+
+## Install
+
+**Requirements:** Visual Studio Code **1.95+** on Windows, macOS, or Linux.
+
+1. Open the **[`vsix/` folder](https://github.com/microsoft/discovery/tree/main/utilities/discovery-toolbox/vsix)** and download the file with the highest version number — `DiscoveryToolbox-v<version>.vsix`.
+2. In VS Code, open the Command Palette (**`Ctrl+Shift+P`** / **`Cmd+Shift+P`**) and run **`Extensions: Install from VSIX…`**, then pick the file you downloaded.
+3. Reload VS Code when prompted, then click the **Discovery Toolbox** icon in the Activity Bar to open the **Welcome** page. From there, jump into the **Onboarding Journey** for a guided walk-through.
+
+> **Updating.** The toolbox checks for new releases on activation and shows a banner on the Welcome page. Click **Install Now** to upgrade in place, or repeat the steps above with a newer `.vsix`.
+
+---
+
+## What Discovery Toolbox does
+
+- 🔧 **End-to-end deployment** — Provision the full Microsoft Discovery platform from scratch (VNets, supercomputers, workspaces, projects, chat models, storage, managed identities) using a bundled, hardened Bicep template, deployed directly from inside VS Code with live terminal output.
+- 🤖 **Agent & tool publishing** — Publish AI agents and containerized tools directly to your Discovery environment. Create from scratch or from the catalog, then build tool images **remotely via ACR Tasks** — no local Docker required — and push them straight to your Azure Container Registry.
+- 🛡️ **Prerequisite validation** — Automatically verify 100+ Azure prerequisites — RBAC roles, resource providers, quotas, policies, **network security perimeter**, and configuration — before deployment, with one-click remediation actions for every issue found.
+- 📊 **Architecture visualization** — See your entire Discovery deployment topology as an interactive diagram (workspaces, projects, agents, supercomputers, storage, networking) with real-time health status. Export as PNG (2×) or SVG, or browse a built-in example dataset.
+- 💰 **Cost analysis** — Track per-resource costs across your Discovery resource groups (daily, weekly, monthly breakdowns). Sortable table with RG and service filters, plus direct links to the Azure Portal cost blade.
+- 📋 **Operational monitoring** — 5-signal diagnostics dashboard (Resource Health, Active Alerts, Advisor Recommendations, Service Health, Diagnostic Settings) across main and managed resource groups, with KPI tiles.
+
+## Key capabilities
+
+- **Onboarding Journey** — Guided 6-step path (Discover → Evaluate → Engage → Triage → Onboard → Deploy & Build) with curated links to the Azure announcement, MS Learn docs, and solutions page.
+- **Dashboard** — At-a-glance health of every section with colored status tiles, KPI/hybrid metric tiles, and completion tracking.
+- **Prerequisites** — Azure CLI, Bicep, login, tenant, subscription, region — including approved-region validation against the Azure locations API.
+- **Deployment Settings** — Region + resource group selectors that act as both the deployment target for new infrastructure and the management scope used to discover existing deployments.
+- **Permission Auditing** — Enumerate 15 RBAC roles with member resolution (users, groups, service principals, managed identities) across subscription, RG, and child-resource scopes.
+- **Role Summary** — 3-persona capability matrix (Platform Admin · Scientist · Reader) showing what each persona can and can't do based on current role assignments.
+- **Quota Management** — vCPU and AI Foundry TPM quotas per region with one-click quota-form data generation; NetApp Files reported informationally.
+- **Network Security** — Four checks for the AIFSPInfrastructure service principal (existence, NSP Perimeter Joiner role, role assignment, Reader at subscription scope) with one-click create/assign actions.
+- **Bicep Deployment** — Validate, configure, and deploy the bundled template with real-time terminal output and a live Infra Status bar.
+- **Agents Page** — Combined catalog browser + agent inventory across workspaces and projects with model, tools, KBs, and Studio/Foundry links.
+- **Tool Publishing** — End-to-end ACR build & push pipeline via ACR Tasks (no local Docker required), with image verification and ARM deploy.
+- **Agent Publishing** — Create agents from scratch or catalog with 8-phase deploy progress events and retry on failure.
+- **Architecture Export** — Export your deployment topology as PNG (2×) or SVG; Show Example mode with realistic sample data.
+- **Tracking Log** — Azure Activity Log viewer with date range presets, search, sort, and expandable detail rows.
+- **Diagnostics** — 5 signals with 6 KPI tiles and 5 collapsible data tables across main + managed resource groups.
+- **Documentation** — Embedded MS Learn docs browser (no git clone required).
+- **Activity Log** — Every Azure API call routed through a logged fetch wrapper for full traceability and troubleshooting.
+- **Update Checker** — Automatic version check on startup with a welcome-page banner and VS Code notification when a new version is available.
+
+## What's new & coming soon
+
+Experimental features are off by default. To opt in, set `mdToolbox.showExperimental` to `true` in VS Code Settings.
+
+| Status | Feature | What it does |
+| --- | --- | --- |
+| Experimental | **Plan-Driven Validation** | Author a declarative 7-stage build plan (workspace · chat model · storage · project · agents · interactions), execute it, and review per-step pass/fail with JSONL audit footers. |
+| Experimental | **Live Agent Chat** | Talk to deployed Discovery agents from a 3-pane chat UX (investigations · conversations · messages) over REST or MCP, with a four-mode transport selector and per-message override. |
+| Experimental | **@discovery Chat Participant** | Slash commands (`/create-agent`, `/explain`) plus `#discovery_*` language model tools for natural-language agent creation, catalog Q&A, and doc search. Requires GitHub Copilot Chat. |
+| Experimental | **MCP Catalog & Invoke** | Browse MCP servers exposed by your Discovery environment and invoke their tools directly from the toolbox. |
+| Planned | **Bookshelves & Knowledge Bases** | Bookshelf enumeration, KB management, and data-ingestion tracking — wired into the Agent Deploy form's Knowledge Bases multi-select and the architecture diagram. |
+| Planned | **Post-Deploy Health Smoke** | Dashboard-level passive health verification, endpoint connectivity tests, and Service Health correlation — complements the active Validation feature. |
+| Planned | **Resource Deletion** | Delete actions for agents, tools, storage containers, and projects with confirmation and optional cascade. |
+| Planned | **Sidebar Status Indicators** | Activity Bar badge with failed-check count plus per-section status icons in the tree. |
+| Planned | **Centralized Input Validation** | Shared validation rules driving inline validation across every editable field. |
+| Planned | **Standalone Resource Provisioning** | Install workspaces, projects, and other components via the Discovery REST API for granular, per-resource control. |
+| Planned | **@discovery Chat — Write Tools & Bundled Skills** | Phase 5+ follow-on to the chat participant. Adds write tools (deploy / configure) callable from chat, and bundled skill files for common workflows. |
+
+## Resources
+
+- [Microsoft Learn — Microsoft Discovery docs](https://learn.microsoft.com/en-us/azure/microsoft-discovery/)
+- [Azure Blog — Microsoft Discovery: advancing agentic R&D at scale](https://azure.microsoft.com/en-us/blog/microsoft-discovery-advancing-agentic-rd-at-scale/)
+- [Azure Solutions page](https://azure.microsoft.com/en-us/solutions/discovery)
+- [Full feature catalog](./About.md)
+- [Privacy & data handling](./PRIVACY.md)
+- [All available Discovery Toolbox versions](https://github.com/microsoft/discovery/tree/main/utilities/discovery-toolbox/vsix)
+
+## Feedback
+
+Found a bug, want a feature, or have general feedback? Open an issue on the [microsoft/discovery](https://github.com/microsoft/discovery/issues/new) repo and include the page you were on plus your toolbox version (Help → About inside the extension).
+
+---
+
+<sub>Published version **v1.1.2** &middot; built from `8155eb4` on 2026-05-29T17:58:52.454Z.</sub>

--- a/utilities/discovery-toolbox/vsix/latest.json
+++ b/utilities/discovery-toolbox/vsix/latest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.1.2",
+  "vsixPath": "vsix/DiscoveryToolbox-v1.1.2.vsix",
+  "sha256": "15c3d521db1e7ad1cccdc7df6643a8b1893e6b779ec793d9c3ee8b246aa042af",
+  "publishedAt": "2026-05-29T17:58:52.454Z"
+}


### PR DESCRIPTION
Ship Discovery Toolbox v1.1.2 to utilities/discovery-toolbox/.

- Source commit (internal): `8155eb404dfe3d10e8449323bf61c3b6a17811eb`
- Built: 2026-05-29T17:58:52.454Z
- VSIX: `utilities/discovery-toolbox/vsix/DiscoveryToolbox-v1.1.2.vsix`
- VSIX sha256: `15c3d521db1e7ad1cccdc7df6643a8b1893e6b779ec793d9c3ee8b246aa042af`

Refreshes `README.md`, `About.md`, `PRIVACY.md`, and `vsix/{latest.json, DiscoveryToolbox-v1.1.2.vsix}` in this folder.

The Discovery Toolbox VS Code extension polls `vsix/latest.json` here via the GitHub Contents API and prompts users to install the new version once merged.

See `utilities/discovery-toolbox/About.md` for the full feature catalog and `utilities/discovery-toolbox/PRIVACY.md` for the data-handling disclosure.