### PR TITLE
Add how-to videos for Discovery app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 agents/gwp-predictor/tools/gwp-predictor/models/*.pt filter=lfs diff=lfs merge=lfs -text
 agents/gwp-predictor/tools/gwp-predictor/models/*.npz filter=lfs diff=lfs merge=lfs -text
+docs/how-to-videos/*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Microsoft Discovery
+# Microsoft Discovery Community Repository
 
 Welcome to the **Microsoft Discovery community** — the public home for the Discovery platform, where users, partners, and the product team build together. Share what you've built, ask questions, file bugs, suggest ideas, and see what other Discovery users are doing across disciplines.
 

--- a/docs/how-to-videos/Discovery app - Creating Agents-Final.mp4
+++ b/docs/how-to-videos/Discovery app - Creating Agents-Final.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a095f193bc222ca16327940cbf43745495cd719c95b256111ccfd7175275944
+size 112382221

--- a/docs/how-to-videos/Discovery app - Creating a bookshelf-Final.mp4
+++ b/docs/how-to-videos/Discovery app - Creating a bookshelf-Final.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8691f6168f2dcabe7a3d23a0c3f422daed0e13da9ebacec9756e1e5862287aec
+size 124431317

--- a/docs/how-to-videos/Discovery app - Run Engine-Task-Final.mp4
+++ b/docs/how-to-videos/Discovery app - Run Engine-Task-Final.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4eadb2874a7ee6bbb1800764e36036c5c4b5268537daaf0dcab2fa7de35d92
+size 243665525

--- a/docs/how-to-videos/Discovery app - Workspace Setup-Final.mp4
+++ b/docs/how-to-videos/Discovery app - Workspace Setup-Final.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95bbbcde3bb424078af177dbb0c93b9f21713b38725933c6bf15a900f43f8a3c
+size 134260927

--- a/docs/how-to-videos/README.md
+++ b/docs/how-to-videos/README.md
@@ -1,0 +1,10 @@
+# How-To Videos
+
+Walkthrough videos for the Discovery app. Videos are stored via [Git LFS](https://git-lfs.com/) — make sure `git lfs` is installed before cloning to fetch the actual files.
+
+| # | Video |
+|---|-------|
+| 1 | [Workspace Setup](Discovery%20app%20-%20Workspace%20Setup-Final.mp4) |
+| 2 | [Creating a Bookshelf](Discovery%20app%20-%20Creating%20a%20bookshelf-Final.mp4) |
+| 3 | [Creating Agents](Discovery%20app%20-%20Creating%20Agents-Final.mp4) |
+| 4 | [Run Engine Task](Discovery%20app%20-%20Run%20Engine-Task-Final.mp4) |


### PR DESCRIPTION
Adds 4 walkthrough videos under `docs/how-to-videos/`, tracked via Git LFS:

- Workspace Setup
- Creating a Bookshelf
- Creating Agents
- Run Engine Task

Also adds `docs/how-to-videos/*.mp4` LFS rule to `.gitattributes`.