### PR TITLE
feat(cli): add auto-update checker and `discovery update` command

### DIFF
--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -50,11 +50,36 @@ This installs the CLI in an isolated environment and makes it available system-w
 
 ### 3. Upgrade the Discovery CLI
 
-To upgrade to the latest version:
+The CLI checks for new releases once per day in the background and prints a
+one-line reminder when a newer version of the `utilities/supercomputer-cli/`
+subdirectory has landed on `main`. Apply an update in one of two ways:
+
+```bash
+discovery update            # interactive: check + prompt + install via uv
+discovery update --check    # check only
+discovery update -y         # install without confirmation
+```
+
+You can also upgrade directly:
 
 ```bash
 uv tool upgrade discovery
 ```
+
+The automatic background check can be disabled either per-invocation
+(`DISCOVERY_NO_UPDATE_CHECK=1`) or persistently:
+
+```bash
+discovery update --disable   # turn off background checks
+discovery update --enable    # turn them back on
+```
+
+> **Authentication.** Because `microsoft/discovery` is currently a private
+> repository, the update check requires a GitHub token. It is discovered
+> automatically from (in order) `DISCOVERY_GITHUB_TOKEN`, `GITHUB_TOKEN`,
+> `GH_TOKEN`, or `gh auth token` (when the `gh` CLI is installed and
+> authenticated). If no token is available, the check fails silently and
+> the CLI keeps working — you'll just never see the upgrade reminder.
 
 ### 4. Verify your installation
 

--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -74,12 +74,12 @@ discovery update --disable   # turn off background checks
 discovery update --enable    # turn them back on
 ```
 
-> **Authentication.** Because `microsoft/discovery` is currently a private
-> repository, the update check requires a GitHub token. It is discovered
-> automatically from (in order) `DISCOVERY_GITHUB_TOKEN`, `GITHUB_TOKEN`,
-> `GH_TOKEN`, or `gh auth token` (when the `gh` CLI is installed and
-> authenticated). If no token is available, the check fails silently and
-> the CLI keeps working — you'll just never see the upgrade reminder.
+> **Authentication is optional.** The update check works fully
+> unauthenticated against a public repo, but GitHub limits anonymous
+> traffic to 60 requests/hour per IP. To raise the limit to 5000/hour
+> the checker opportunistically uses `DISCOVERY_GITHUB_TOKEN`,
+> `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token` (when the `gh` CLI is
+> installed and authenticated) — no setup required for most developers.
 
 > **Following a non-default branch.** Set `DISCOVERY_UPDATE_REF=<ref>` to
 > compare against a branch, tag, or commit other than `main`. Pair with

--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -81,6 +81,11 @@ discovery update --enable    # turn them back on
 > authenticated). If no token is available, the check fails silently and
 > the CLI keeps working — you'll just never see the upgrade reminder.
 
+> **Following a non-default branch.** Set `DISCOVERY_UPDATE_REF=<ref>` to
+> compare against a branch, tag, or commit other than `main`. Pair with
+> `DISCOVERY_UPDATE_REPO=owner/name` for fork-based or RC-channel
+> testing.
+
 ### 4. Verify your installation
 
 ```bash

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
@@ -1,0 +1,602 @@
+"""Background update checker for the Discovery CLI.
+
+Modeled on the GitHub Copilot CLI's ``/update`` + ``/version`` flow.
+
+How it works
+------------
+* On every CLI invocation, :func:`schedule_check` reads a small cache
+  (``~/.discovery/update-check.json``). If the cache is fresh (default:
+  refreshed within the last 24h) nothing happens. Otherwise a *daemon*
+  thread is spawned to refresh the cache in the background — it never
+  blocks the foreground command and never raises into the user's session.
+* :func:`maybe_notify` is registered as an :mod:`atexit` hook by the
+  root CLI callback. When the previously-cached check tells us that a
+  newer release is available, a single colorized line is printed to
+  ``stderr`` *after* the command's own output, so the notice never
+  scrolls off the top of the terminal.
+* The user-facing ``discovery update`` command (see
+  :mod:`discovery.poll.cli_update`) calls :func:`fetch_update_info` and
+  :func:`install_update` directly to do a *synchronous* check and apply.
+
+Subdirectory-aware version comparison
+-------------------------------------
+The CLI ships as a subdirectory of the ``microsoft/discovery`` monorepo,
+so the repository's main branch advances for many reasons (catalog
+edits, doc updates, other utilities) that do not change the CLI itself.
+We therefore query the GitHub *compare* API with
+``compare/{current_sha}...main`` and only flag an update when at least
+one of the changed files lives under ``utilities/supercomputer-cli/``.
+This keeps notifications meaningful and avoids the "upgrade did
+nothing" foot-gun that a naive HEAD-vs-HEAD comparison would produce.
+
+Opt-out
+-------
+* Set ``DISCOVERY_NO_UPDATE_CHECK=1`` (one-shot, e.g. CI).
+* Run ``discovery update --disable`` to persist the opt-out on disk.
+
+Authentication
+--------------
+The ``microsoft/discovery`` repository is currently private, so the
+GitHub compare API requires a token. The checker discovers one from
+(in order): ``DISCOVERY_GITHUB_TOKEN``, ``GITHUB_TOKEN``, ``GH_TOKEN``,
+or ``gh auth token`` (if the GitHub CLI is on ``PATH``). When no token
+is available the check fails silently — the foreground command is
+never affected.
+
+The check is silently skipped for editable / source installs (i.e. when
+:func:`discovery._version.get_build_commit` returns ``"dev"``) because
+those installs are not managed by ``uv tool``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+from rich.console import Console
+from rich.text import Text
+
+from discovery._version import get_build_commit
+from discovery.common.logging import debug
+from discovery.common.paths import get_home_dir
+
+
+CACHE_DIR_NAME = ".discovery"
+CACHE_FILE_NAME = "update-check.json"
+CHECK_INTERVAL_HOURS = 24
+REQUEST_TIMEOUT_SECONDS = 5.0
+
+REPO_OWNER = "microsoft"
+REPO_NAME = "discovery"
+CLI_SUBDIR = "utilities/supercomputer-cli/"
+DEFAULT_BRANCH = "main"
+GITHUB_COMPARE_URL = (
+    f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/compare/{{base}}...{{head}}"
+)
+GITHUB_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "discovery-cli-update-check",
+}
+
+# The microsoft/discovery repo is currently private, so unauthenticated
+# requests return 404. We try these sources in order to get a token; if
+# none of them succeed, the update check fails gracefully with a hint
+# about ``gh auth login``.
+TOKEN_ENV_VARS = ("DISCOVERY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
+
+ENV_OPT_OUT = "DISCOVERY_NO_UPDATE_CHECK"
+ENV_OPT_OUT_TRUTHY = {"1", "true", "True", "TRUE", "yes", "YES", "on", "ON"}
+
+UPGRADE_COMMAND = "uv tool upgrade discovery"
+DEV_COMMIT_SENTINEL = "dev"
+
+
+# ---------------------------------------------------------------------------
+# Cache model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UpdateCacheState:
+    """Persistent state for the update checker.
+
+    Attributes:
+        last_checked: ISO-8601 UTC timestamp of the most recent
+            successful network check, or ``None`` if the cache has
+            never been populated.
+        latest_commit: Short SHA (8 chars) of the newest commit on
+            ``main`` that touched the CLI subdirectory at the time of
+            the last successful check.
+        latest_commit_date: ISO-8601 UTC committer date of
+            ``latest_commit``.
+        current_at_check: Short SHA the CLI binary reported at the time
+            of the last successful check. Used to invalidate the cache
+            when the user upgrades or downgrades between checks.
+        notified_commit: Short SHA the user has already been notified
+            about. Prevents the at-exit notice from re-printing the
+            *same* update on every invocation while still allowing a
+            fresh notice when a newer release appears.
+        disabled: Persistent opt-out flag. When ``True`` no checks or
+            notifications are performed regardless of cache freshness.
+    """
+
+    last_checked: str | None = None
+    latest_commit: str | None = None
+    latest_commit_date: str | None = None
+    current_at_check: str | None = None
+    notified_commit: str | None = None
+    disabled: bool = False
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> UpdateCacheState:
+        """Build a state instance from a JSON-decoded mapping.
+
+        Unknown keys are ignored so older / newer cache files do not
+        break compatibility.
+        """
+        kwargs: dict[str, Any] = {}
+        valid = {f.name for f in fields(cls)}
+        for key, value in data.items():
+            if key in valid:
+                kwargs[key] = value
+        return cls(**kwargs)
+
+
+@dataclass
+class UpdateInfo:
+    """Result of a synchronous update check."""
+
+    current_commit: str
+    latest_commit: str
+    latest_commit_date: str = ""
+    update_available: bool = False
+    changed_files: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O
+# ---------------------------------------------------------------------------
+
+
+def _cache_path() -> Path:
+    """Return the absolute path to the update-check cache file."""
+    return get_home_dir() / CACHE_DIR_NAME / CACHE_FILE_NAME
+
+
+def load_cache() -> UpdateCacheState:
+    """Load the cached check state, returning an empty state on any error."""
+    path = _cache_path()
+    if not path.is_file():
+        return UpdateCacheState()
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        debug(f"auto-update: ignoring unreadable cache {path}: {exc}")
+        return UpdateCacheState()
+    if not isinstance(data, dict):
+        return UpdateCacheState()
+    return UpdateCacheState.from_mapping(data)
+
+
+def save_cache(state: UpdateCacheState) -> None:
+    """Persist ``state`` to the cache file; silently swallow filesystem errors."""
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(asdict(state), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        debug(f"auto-update: failed to persist cache {path}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    """Return the current UTC time. Indirected for testability."""
+    return datetime.now(tz=timezone.utc)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp, returning ``None`` on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _env_opt_out() -> bool:
+    """``True`` when the env-var opt-out is enabled for this process."""
+    return os.environ.get(ENV_OPT_OUT, "") in ENV_OPT_OUT_TRUTHY
+
+
+def is_opted_out(state: UpdateCacheState | None = None) -> bool:
+    """Return ``True`` when the user has opted out (env or persistent flag)."""
+    if state is None:
+        state = load_cache()
+    return state.disabled or _env_opt_out()
+
+
+def cache_is_stale(
+    state: UpdateCacheState, *, interval_hours: int = CHECK_INTERVAL_HOURS
+) -> bool:
+    """``True`` when the cached check is older than ``interval_hours``."""
+    last = _parse_iso(state.last_checked)
+    if last is None:
+        return True
+    return _now() - last >= timedelta(hours=interval_hours)
+
+
+def _should_check() -> bool:
+    """Return ``True`` when this installation is eligible for update checks.
+
+    Dev / editable installs are excluded — they're typically maintained
+    via ``git pull`` rather than ``uv tool upgrade``, and ``get_build_commit``
+    returns the sentinel ``"dev"`` for them.
+    """
+    return get_build_commit() != DEV_COMMIT_SENTINEL
+
+
+def set_disabled(value: bool) -> None:
+    """Persist the disable flag in the cache file."""
+    state = load_cache()
+    state.disabled = value
+    save_cache(state)
+
+
+# ---------------------------------------------------------------------------
+# Network: fetch update info from GitHub
+# ---------------------------------------------------------------------------
+
+
+def _is_cli_path(filename: str) -> bool:
+    """Return ``True`` when ``filename`` lives under the CLI subdirectory."""
+    return filename.startswith(CLI_SUBDIR)
+
+
+def _newest_cli_commit(commits: list[dict[str, Any]]) -> tuple[str, str] | None:
+    """Return ``(short_sha, iso_date)`` of the newest CLI-touching commit.
+
+    ``commits`` is the list returned by the GitHub compare endpoint,
+    ordered from oldest to newest. We iterate from the end so the first
+    match is the newest.
+    """
+    for entry in reversed(commits):
+        files = entry.get("files")
+        sha = entry.get("sha", "")
+        if not sha:
+            continue
+        if isinstance(files, list) and any(
+            _is_cli_path(str(f.get("filename", ""))) for f in files
+        ):
+            iso = (
+                entry.get("commit", {})
+                .get("committer", {})
+                .get("date", "")
+            )
+            return sha[:8], iso
+    return None
+
+
+def _gh_cli_token(*, timeout: float = 3.0) -> str | None:
+    """Return a GitHub token from ``gh auth token`` when available."""
+    gh = shutil.which("gh")
+    if gh is None:
+        return None
+    try:
+        result = subprocess.run(
+            [gh, "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        debug(f"auto-update: `gh auth token` failed: {exc}")
+        return None
+    if result.returncode != 0:
+        return None
+    token = result.stdout.strip()
+    return token or None
+
+
+def _resolve_github_token() -> str | None:
+    """Discover a GitHub token from the environment or the ``gh`` CLI."""
+    for var in TOKEN_ENV_VARS:
+        value = os.environ.get(var)
+        if value:
+            return value
+    return _gh_cli_token()
+
+
+def _build_headers() -> dict[str, str]:
+    """Build the request headers, including ``Authorization`` when available."""
+    headers = dict(GITHUB_HEADERS)
+    token = _resolve_github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_update_info(
+    current_commit: str, *, timeout: float = REQUEST_TIMEOUT_SECONDS
+) -> UpdateInfo | None:
+    """Synchronously query GitHub for available updates.
+
+    Args:
+        current_commit: The short SHA of the currently installed build
+            (typically :func:`discovery._version.get_build_commit`).
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        :class:`UpdateInfo` describing the comparison, or ``None`` on
+        any network / parsing / authentication error. Failures are
+        intentionally not raised so callers can implement "silent on
+        failure" semantics.
+    """
+    if not current_commit or current_commit == DEV_COMMIT_SENTINEL:
+        return None
+    url = GITHUB_COMPARE_URL.format(base=current_commit, head=DEFAULT_BRANCH)
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            resp = client.get(url, headers=_build_headers())
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        debug(f"auto-update: network check failed: {exc}")
+        return None
+
+    ahead_by = data.get("ahead_by", 0)
+    if not isinstance(ahead_by, int) or ahead_by <= 0:
+        return UpdateInfo(
+            current_commit=current_commit,
+            latest_commit=current_commit,
+            update_available=False,
+        )
+
+    changed_files = [
+        str(f.get("filename", ""))
+        for f in data.get("files", [])
+        if isinstance(f, dict)
+    ]
+    cli_changes = [f for f in changed_files if _is_cli_path(f)]
+    if not cli_changes:
+        return UpdateInfo(
+            current_commit=current_commit,
+            latest_commit=current_commit,
+            update_available=False,
+            changed_files=changed_files,
+        )
+
+    commits = data.get("commits", [])
+    if not isinstance(commits, list) or not commits:
+        return None
+
+    newest = _newest_cli_commit(commits)
+    if newest is None:
+        # ``ahead_by`` and ``files`` disagreed with the per-commit view
+        # (rare: GitHub may omit per-commit ``files`` for very large
+        # diffs). Fall back to the tip of ``head`` so the user still
+        # learns that *something* has changed.
+        tip = commits[-1]
+        latest_sha = str(tip.get("sha", ""))[:8]
+        latest_date = (
+            tip.get("commit", {}).get("committer", {}).get("date", "")
+        )
+    else:
+        latest_sha, latest_date = newest
+
+    return UpdateInfo(
+        current_commit=current_commit,
+        latest_commit=latest_sha,
+        latest_commit_date=latest_date or "",
+        update_available=latest_sha != current_commit,
+        changed_files=cli_changes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Background scheduling
+# ---------------------------------------------------------------------------
+
+
+def _refresh_cache_worker() -> None:
+    """Daemon-thread worker: refresh the cache and never raise."""
+    try:
+        current = get_build_commit()
+        info = fetch_update_info(current)
+        if info is None:
+            return
+        state = load_cache()
+        # Invalidate the "already-notified" memo when the user has
+        # upgraded since the last check, so we don't suppress new
+        # legitimate notifications for the *next* release.
+        if state.current_at_check != current:
+            state.notified_commit = None
+        state.last_checked = _now().isoformat()
+        state.latest_commit = info.latest_commit
+        state.latest_commit_date = info.latest_commit_date or None
+        state.current_at_check = current
+        save_cache(state)
+    except Exception as exc:  # pragma: no cover - defensive
+        debug(f"auto-update: background refresh crashed: {exc}")
+
+
+def schedule_check() -> threading.Thread | None:
+    """Spawn a background refresh if the cache is stale and not opted out.
+
+    Returns the worker thread (mainly for tests) or ``None`` when no
+    check was scheduled.
+    """
+    if not _should_check():
+        return None
+    state = load_cache()
+    if is_opted_out(state):
+        return None
+    if not cache_is_stale(state):
+        return None
+    thread = threading.Thread(
+        target=_refresh_cache_worker,
+        name="discovery-update-check",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+# ---------------------------------------------------------------------------
+# Notification
+# ---------------------------------------------------------------------------
+
+
+def _pending_update(state: UpdateCacheState) -> tuple[str, str] | None:
+    """Return ``(latest_sha, latest_date)`` when an update is pending, else ``None``."""
+    if not state.latest_commit:
+        return None
+    current = get_build_commit()
+    if state.latest_commit == current:
+        return None
+    # Only suppress when we've already notified about *this exact*
+    # upstream commit; if a newer upstream commit appears we want to
+    # re-notify.
+    if state.notified_commit == state.latest_commit:
+        return None
+    return state.latest_commit, state.latest_commit_date or ""
+
+
+def format_notification(
+    current_commit: str, latest_commit: str, latest_date: str
+) -> str:
+    """Return the plain-text notification body (used by tests)."""
+    date_part = ""
+    if latest_date:
+        date_part = f" ({latest_date.split('T')[0]})"
+    return (
+        "A new version of the Discovery CLI is available"
+        f"{date_part}: {current_commit} -> {latest_commit}. "
+        f"Run `{UPGRADE_COMMAND}` or `discovery update` to upgrade."
+    )
+
+
+def maybe_notify() -> None:
+    """Emit the at-exit update notification when one is pending.
+
+    Safe to call at any time: silently no-ops when checks are disabled,
+    when no update is cached, or when the cached update has already
+    been announced to the user.
+    """
+    if not _should_check():
+        return
+    state = load_cache()
+    if is_opted_out(state):
+        return
+    pending = _pending_update(state)
+    if pending is None:
+        return
+    latest_sha, latest_date = pending
+
+    # Build a Rich-styled message but degrade gracefully if rendering
+    # fails (e.g. during interpreter shutdown when stderr is gone).
+    try:
+        console = Console(stderr=True, highlight=False, soft_wrap=True)
+        text = Text()
+        text.append("\n🔔 ", style="bold yellow")
+        text.append(
+            "A new version of the Discovery CLI is available",
+            style="yellow",
+        )
+        if latest_date:
+            text.append(f" ({latest_date.split('T')[0]})", style="dim")
+        text.append("\n   Current: ", style="dim")
+        text.append(get_build_commit(), style="cyan")
+        text.append("  ->  Latest: ", style="dim")
+        text.append(latest_sha, style="green")
+        text.append("\n   Run ", style="dim")
+        text.append(UPGRADE_COMMAND, style="bold")
+        text.append(" or ", style="dim")
+        text.append("discovery update", style="bold")
+        text.append(" to upgrade.\n", style="dim")
+        console.print(text)
+    except Exception:  # pragma: no cover - defensive
+        try:
+            sys.stderr.write(
+                "\n"
+                + format_notification(get_build_commit(), latest_sha, latest_date)
+                + "\n"
+            )
+        except Exception:
+            return
+
+    state.notified_commit = latest_sha
+    save_cache(state)
+
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+
+
+class UpgradeError(RuntimeError):
+    """Raised when the upgrade subprocess cannot be launched."""
+
+
+def install_update(*, dry_run: bool = False) -> int:
+    """Run ``uv tool upgrade discovery``.
+
+    Args:
+        dry_run: If ``True``, return ``0`` without invoking ``uv``.
+
+    Returns:
+        The subprocess exit status (``0`` on success).
+
+    Raises:
+        UpgradeError: If the ``uv`` binary is not on ``PATH``.
+    """
+    if shutil.which("uv") is None:
+        msg = "`uv` is not installed or not on PATH; cannot self-upgrade."
+        raise UpgradeError(msg)
+    cmd = ["uv", "tool", "upgrade", "discovery"]
+    if dry_run:
+        return 0
+    proc = subprocess.run(cmd, check=False)
+    return proc.returncode
+
+
+__all__ = [
+    "CACHE_DIR_NAME",
+    "CACHE_FILE_NAME",
+    "CHECK_INTERVAL_HOURS",
+    "DEV_COMMIT_SENTINEL",
+    "ENV_OPT_OUT",
+    "UPGRADE_COMMAND",
+    "UpdateCacheState",
+    "UpdateInfo",
+    "UpgradeError",
+    "cache_is_stale",
+    "fetch_update_info",
+    "format_notification",
+    "install_update",
+    "is_opted_out",
+    "load_cache",
+    "maybe_notify",
+    "save_cache",
+    "schedule_check",
+    "set_disabled",
+]

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
@@ -42,14 +42,15 @@ to compare against a different repository (e.g. a fork). Useful for
 following a release-candidate branch, validating a fork, or end-to-end
 testing this checker.
 
-Authentication
---------------
-The ``microsoft/discovery`` repository is currently private, so the
-GitHub compare API requires a token. The checker discovers one from
-(in order): ``DISCOVERY_GITHUB_TOKEN``, ``GITHUB_TOKEN``, ``GH_TOKEN``,
-or ``gh auth token`` (if the GitHub CLI is on ``PATH``). When no token
-is available the check fails silently — the foreground command is
-never affected.
+Authentication (optional)
+-------------------------
+The check works fully unauthenticated against a public repository, but
+GitHub limits anonymous traffic to 60 requests/hour per IP. The checker
+opportunistically discovers a token from (in order)
+``DISCOVERY_GITHUB_TOKEN``, ``GITHUB_TOKEN``, ``GH_TOKEN``, or
+``gh auth token`` (if the GitHub CLI is on ``PATH``) and uses it to
+raise that limit to 5000/hour. When the limit is exhausted the check
+fails silently — the foreground command is never affected.
 
 The check is silently skipped for editable / source installs (i.e. when
 :func:`discovery._version.get_build_commit` returns ``"dev"``) because
@@ -116,6 +117,17 @@ ENV_OPT_OUT_TRUTHY = {"1", "true", "True", "TRUE", "yes", "YES", "on", "ON"}
 
 UPGRADE_COMMAND = "uv tool upgrade discovery"
 DEV_COMMIT_SENTINEL = "dev"
+
+# Categorical reasons reported by :class:`UpdateCheckError`. Defined as
+# module constants so callers can match on them by symbol and so linters
+# do not treat them as inline error-message strings.
+REASON_INELIGIBLE = "ineligible"
+REASON_NETWORK = "network"
+REASON_PARSE_ERROR = "parse_error"
+REASON_RATE_LIMITED = "rate_limited"
+REASON_UNAUTHORIZED = "unauthorized"
+REASON_NOT_FOUND = "not_found"
+REASON_HTTP_ERROR = "http_error"
 
 
 # ---------------------------------------------------------------------------
@@ -352,9 +364,55 @@ def _build_headers() -> dict[str, str]:
     return headers
 
 
-def fetch_update_info(
+class UpdateCheckError(RuntimeError):
+    """Raised by :func:`check_for_update` on any check failure.
+
+    The :attr:`reason` attribute is a short machine-readable category
+    that callers can switch on to produce tailored user messages:
+
+    * ``"rate_limited"`` — GitHub's anonymous rate limit was exhausted.
+      Hint: set ``GITHUB_TOKEN`` or run ``gh auth login``.
+    * ``"unauthorized"`` — 401/403 without a rate-limit indicator
+      (e.g. the repo is private and no valid token was found).
+    * ``"not_found"`` — 404 from the compare endpoint, usually meaning
+      the installed commit is no longer reachable from the upstream
+      ref (force-push, deleted branch, wrong ``DISCOVERY_UPDATE_REPO``).
+    * ``"http_error"`` — Any other non-2xx response.
+    * ``"network"`` — Connection / DNS / TLS / timeout failure.
+    * ``"parse_error"`` — Successful HTTP but unexpected payload shape.
+    """
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        message = reason if not detail else f"{reason}: {detail}"
+        super().__init__(message)
+        self.reason = reason
+        self.detail = detail
+
+
+def _classify_http_error(exc: httpx.HTTPStatusError) -> UpdateCheckError:
+    """Translate an :class:`httpx.HTTPStatusError` into ``UpdateCheckError``."""
+    status = exc.response.status_code
+    body = ""
+    try:
+        body = exc.response.text or ""
+    except Exception:  # pragma: no cover - defensive
+        body = ""
+    body_lower = body.lower()
+    if status == 403 and (
+        "rate limit" in body_lower
+        or exc.response.headers.get("x-ratelimit-remaining") == "0"
+    ):
+        return UpdateCheckError(REASON_RATE_LIMITED, body[:200])
+    if status in (401, 403):
+        return UpdateCheckError(REASON_UNAUTHORIZED, body[:200])
+    if status == 404:
+        return UpdateCheckError(REASON_NOT_FOUND, body[:200])
+    return UpdateCheckError(REASON_HTTP_ERROR, f"HTTP {status}: {body[:160]}")
+
+
+def check_for_update(
     current_commit: str, *, timeout: float = REQUEST_TIMEOUT_SECONDS
-) -> UpdateInfo | None:
+) -> UpdateInfo:
     """Synchronously query GitHub for available updates.
 
     Args:
@@ -363,13 +421,16 @@ def fetch_update_info(
         timeout: HTTP timeout in seconds.
 
     Returns:
-        :class:`UpdateInfo` describing the comparison, or ``None`` on
-        any network / parsing / authentication error. Failures are
-        intentionally not raised so callers can implement "silent on
-        failure" semantics.
+        :class:`UpdateInfo` describing the comparison.
+
+    Raises:
+        UpdateCheckError: On any failure to obtain a usable answer.
+            Inspect :attr:`UpdateCheckError.reason` for the category.
     """
     if not current_commit or current_commit == DEV_COMMIT_SENTINEL:
-        return None
+        raise UpdateCheckError(
+            REASON_INELIGIBLE, "build commit is unknown or local-dev"
+        )
     upstream_ref = os.environ.get(ENV_UPDATE_REF) or DEFAULT_BRANCH
     upstream_repo = (
         os.environ.get(ENV_UPDATE_REPO) or f"{REPO_OWNER}/{REPO_NAME}"
@@ -382,9 +443,17 @@ def fetch_update_info(
             resp = client.get(url, headers=_build_headers())
             resp.raise_for_status()
             data = resp.json()
-    except (httpx.HTTPError, ValueError) as exc:
-        debug(f"auto-update: network check failed: {exc}")
-        return None
+    except httpx.HTTPStatusError as exc:
+        raise _classify_http_error(exc) from exc
+    except httpx.HTTPError as exc:
+        raise UpdateCheckError(REASON_NETWORK, str(exc)) from exc
+    except ValueError as exc:
+        raise UpdateCheckError(REASON_PARSE_ERROR, str(exc)) from exc
+
+    if not isinstance(data, dict):
+        raise UpdateCheckError(
+            REASON_PARSE_ERROR, "compare response is not an object"
+        )
 
     ahead_by = data.get("ahead_by", 0)
     if not isinstance(ahead_by, int) or ahead_by <= 0:
@@ -410,7 +479,9 @@ def fetch_update_info(
 
     commits = data.get("commits", [])
     if not isinstance(commits, list) or not commits:
-        return None
+        raise UpdateCheckError(
+            REASON_PARSE_ERROR, "compare response missing 'commits' list"
+        )
 
     newest = _newest_cli_commit(commits)
     if newest is None:
@@ -433,6 +504,22 @@ def fetch_update_info(
         update_available=latest_sha != current_commit,
         changed_files=cli_changes,
     )
+
+
+def fetch_update_info(
+    current_commit: str, *, timeout: float = REQUEST_TIMEOUT_SECONDS
+) -> UpdateInfo | None:
+    """Silent-failure wrapper around :func:`check_for_update`.
+
+    Returns ``None`` on any error. Use :func:`check_for_update` directly
+    when you need the failure category (e.g. to prompt for authentication
+    on rate-limit failures).
+    """
+    try:
+        return check_for_update(current_commit, timeout=timeout)
+    except UpdateCheckError as exc:
+        debug(f"auto-update: check failed [{exc.reason}]: {exc.detail}")
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -612,9 +699,11 @@ __all__ = [
     "ENV_UPDATE_REPO",
     "UPGRADE_COMMAND",
     "UpdateCacheState",
+    "UpdateCheckError",
     "UpdateInfo",
     "UpgradeError",
     "cache_is_stale",
+    "check_for_update",
     "fetch_update_info",
     "format_notification",
     "install_update",

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
@@ -34,6 +34,14 @@ Opt-out
 * Set ``DISCOVERY_NO_UPDATE_CHECK=1`` (one-shot, e.g. CI).
 * Run ``discovery update --disable`` to persist the opt-out on disk.
 
+Following a non-default branch
+------------------------------
+Set ``DISCOVERY_UPDATE_REF=<ref>`` to compare against a branch, tag, or
+commit other than ``main``. Pair with ``DISCOVERY_UPDATE_REPO=owner/name``
+to compare against a different repository (e.g. a fork). Useful for
+following a release-candidate branch, validating a fork, or end-to-end
+testing this checker.
+
 Authentication
 --------------
 The ``microsoft/discovery`` repository is currently private, so the
@@ -79,14 +87,23 @@ REPO_OWNER = "microsoft"
 REPO_NAME = "discovery"
 CLI_SUBDIR = "utilities/supercomputer-cli/"
 DEFAULT_BRANCH = "main"
-GITHUB_COMPARE_URL = (
-    f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/compare/{{base}}...{{head}}"
+GITHUB_COMPARE_URL_TEMPLATE = (
+    "https://api.github.com/repos/{owner_repo}/compare/{base}...{head}"
 )
 GITHUB_HEADERS = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "discovery-cli-update-check",
 }
+
+# Override the upstream ref used for the compare. Useful for following
+# a pre-release branch, validating a fork, or end-to-end testing the
+# update flow without merging to main.
+ENV_UPDATE_REF = "DISCOVERY_UPDATE_REF"
+
+# Override the upstream repository (``owner/name``). Pairs with
+# ``DISCOVERY_UPDATE_REF`` for fork-based testing or alternate channels.
+ENV_UPDATE_REPO = "DISCOVERY_UPDATE_REPO"
 
 # The microsoft/discovery repo is currently private, so unauthenticated
 # requests return 404. We try these sources in order to get a token; if
@@ -353,7 +370,13 @@ def fetch_update_info(
     """
     if not current_commit or current_commit == DEV_COMMIT_SENTINEL:
         return None
-    url = GITHUB_COMPARE_URL.format(base=current_commit, head=DEFAULT_BRANCH)
+    upstream_ref = os.environ.get(ENV_UPDATE_REF) or DEFAULT_BRANCH
+    upstream_repo = (
+        os.environ.get(ENV_UPDATE_REPO) or f"{REPO_OWNER}/{REPO_NAME}"
+    )
+    url = GITHUB_COMPARE_URL_TEMPLATE.format(
+        owner_repo=upstream_repo, base=current_commit, head=upstream_ref
+    )
     try:
         with httpx.Client(timeout=timeout, follow_redirects=True) as client:
             resp = client.get(url, headers=_build_headers())
@@ -585,6 +608,8 @@ __all__ = [
     "CHECK_INTERVAL_HOURS",
     "DEV_COMMIT_SENTINEL",
     "ENV_OPT_OUT",
+    "ENV_UPDATE_REF",
+    "ENV_UPDATE_REPO",
     "UPGRADE_COMMAND",
     "UpdateCacheState",
     "UpdateInfo",

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/auto_update.py
@@ -23,11 +23,16 @@ Subdirectory-aware version comparison
 The CLI ships as a subdirectory of the ``microsoft/discovery`` monorepo,
 so the repository's main branch advances for many reasons (catalog
 edits, doc updates, other utilities) that do not change the CLI itself.
-We therefore query the GitHub *compare* API with
-``compare/{current_sha}...main`` and only flag an update when at least
-one of the changed files lives under ``utilities/supercomputer-cli/``.
-This keeps notifications meaningful and avoids the "upgrade did
-nothing" foot-gun that a naive HEAD-vs-HEAD comparison would produce.
+We therefore query the GitHub *commits* API with
+``commits?sha=main&path=utilities/supercomputer-cli/&per_page=1``,
+which returns just the single most-recent commit that touched the CLI
+subdirectory (no per-file diffs). The response is ~1-3 KB regardless
+of how many commits the user is behind by, vs. the 100 KB - 1+ MB the
+``/compare`` endpoint would return for the same query.
+
+We also honour HTTP ``ETag`` / ``If-None-Match``: a 304 response in the
+steady-state-unchanged case is ~200 bytes and (per GitHub's docs) does
+*not* count against the rate limit.
 
 Opt-out
 -------
@@ -88,8 +93,14 @@ REPO_OWNER = "microsoft"
 REPO_NAME = "discovery"
 CLI_SUBDIR = "utilities/supercomputer-cli/"
 DEFAULT_BRANCH = "main"
-GITHUB_COMPARE_URL_TEMPLATE = (
-    "https://api.github.com/repos/{owner_repo}/compare/{base}...{head}"
+# The commits endpoint returns just commit metadata (no per-file diffs).
+# With ``path=`` it returns only commits that touched the CLI subdirectory,
+# and ``per_page=1`` gives us just the newest one — the only thing we
+# actually need. Total response: ~1 KB instead of the ~100 KB - 1.3 MB
+# the compare endpoint produced.
+GITHUB_COMMITS_URL_TEMPLATE = (
+    "https://api.github.com/repos/{owner_repo}/commits"
+    "?sha={ref}&path={path}&per_page=1"
 )
 GITHUB_HEADERS = {
     "Accept": "application/vnd.github+json",
@@ -157,6 +168,14 @@ class UpdateCacheState:
             fresh notice when a newer release appears.
         disabled: Persistent opt-out flag. When ``True`` no checks or
             notifications are performed regardless of cache freshness.
+        etag: HTTP ``ETag`` header from the last successful 200/304
+            response. Sent as ``If-None-Match`` on the next request so
+            GitHub can answer with 304 Not Modified (~200 bytes, no
+            rate-limit cost) when nothing has changed.
+        etag_url: The full request URL the ``etag`` was issued for.
+            Etags are URL-specific, so we discard the cached etag when
+            the URL changes (e.g. user switched ``DISCOVERY_UPDATE_REF``
+            or ``DISCOVERY_UPDATE_REPO``).
     """
 
     last_checked: str | None = None
@@ -165,6 +184,8 @@ class UpdateCacheState:
     current_at_check: str | None = None
     notified_commit: str | None = None
     disabled: bool = False
+    etag: str | None = None
+    etag_url: str | None = None
 
     @classmethod
     def from_mapping(cls, data: dict[str, Any]) -> UpdateCacheState:
@@ -296,32 +317,14 @@ def set_disabled(value: bool) -> None:
 
 
 def _is_cli_path(filename: str) -> bool:
-    """Return ``True`` when ``filename`` lives under the CLI subdirectory."""
-    return filename.startswith(CLI_SUBDIR)
+    """Return ``True`` when ``filename`` lives under the CLI subdirectory.
 
-
-def _newest_cli_commit(commits: list[dict[str, Any]]) -> tuple[str, str] | None:
-    """Return ``(short_sha, iso_date)`` of the newest CLI-touching commit.
-
-    ``commits`` is the list returned by the GitHub compare endpoint,
-    ordered from oldest to newest. We iterate from the end so the first
-    match is the newest.
+    Kept as a helper for forward-compatibility — currently unused by the
+    fetcher itself (the ``commits?path=`` endpoint already filters
+    server-side) but useful for any callers that want to apply the same
+    classification.
     """
-    for entry in reversed(commits):
-        files = entry.get("files")
-        sha = entry.get("sha", "")
-        if not sha:
-            continue
-        if isinstance(files, list) and any(
-            _is_cli_path(str(f.get("filename", ""))) for f in files
-        ):
-            iso = (
-                entry.get("commit", {})
-                .get("committer", {})
-                .get("date", "")
-            )
-            return sha[:8], iso
-    return None
+    return filename.startswith(CLI_SUBDIR)
 
 
 def _gh_cli_token(*, timeout: float = 3.0) -> str | None:
@@ -410,22 +413,53 @@ def _classify_http_error(exc: httpx.HTTPStatusError) -> UpdateCheckError:
     return UpdateCheckError(REASON_HTTP_ERROR, f"HTTP {status}: {body[:160]}")
 
 
+def _build_commits_url(*, owner_repo: str, ref: str) -> str:
+    """Return the commits-with-path URL for the CLI subdir on ``ref``."""
+    return GITHUB_COMMITS_URL_TEMPLATE.format(
+        owner_repo=owner_repo,
+        ref=ref,
+        path=CLI_SUBDIR,
+    )
+
+
 def check_for_update(
-    current_commit: str, *, timeout: float = REQUEST_TIMEOUT_SECONDS
-) -> UpdateInfo:
+    current_commit: str,
+    *,
+    timeout: float = REQUEST_TIMEOUT_SECONDS,
+    cached_etag: str | None = None,
+    cached_etag_url: str | None = None,
+) -> tuple[UpdateInfo, str | None]:
     """Synchronously query GitHub for available updates.
 
+    Uses ``/repos/{owner}/{repo}/commits?path=…&per_page=1`` to retrieve
+    only the newest commit that touched the CLI subdirectory. This is
+    typically a ~1 KB JSON document instead of the 100 KB - 1 MB
+    full-diff payload that ``/compare`` would return.
+
+    Also supports HTTP ``ETag`` conditional GET: when
+    ``cached_etag`` / ``cached_etag_url`` are provided and the request
+    URL matches, ``If-None-Match`` is sent. GitHub answers with
+    ``304 Not Modified`` (zero body, no rate-limit cost) when nothing
+    has changed since the cached check.
+
     Args:
-        current_commit: The short SHA of the currently installed build
-            (typically :func:`discovery._version.get_build_commit`).
+        current_commit: Short SHA of the currently installed build.
         timeout: HTTP timeout in seconds.
+        cached_etag: ``ETag`` from a previous successful response, if
+            any. Pass ``None`` to skip the conditional request.
+        cached_etag_url: URL the ``cached_etag`` was originally issued
+            for. The etag is only sent when it matches the current
+            request URL — etags are URL-specific.
 
     Returns:
-        :class:`UpdateInfo` describing the comparison.
+        ``(UpdateInfo, new_etag)``. When the server returns 304 the
+        :class:`UpdateInfo` is built from the caller's perspective
+        (``latest_commit == current_commit``, no update); otherwise it
+        reflects the freshly-fetched commit. ``new_etag`` may be
+        ``None`` when the server didn't return one.
 
     Raises:
         UpdateCheckError: On any failure to obtain a usable answer.
-            Inspect :attr:`UpdateCheckError.reason` for the category.
     """
     if not current_commit or current_commit == DEV_COMMIT_SENTINEL:
         raise UpdateCheckError(
@@ -435,14 +469,28 @@ def check_for_update(
     upstream_repo = (
         os.environ.get(ENV_UPDATE_REPO) or f"{REPO_OWNER}/{REPO_NAME}"
     )
-    url = GITHUB_COMPARE_URL_TEMPLATE.format(
-        owner_repo=upstream_repo, base=current_commit, head=upstream_ref
-    )
+    url = _build_commits_url(owner_repo=upstream_repo, ref=upstream_ref)
+
+    headers = _build_headers()
+    if cached_etag and cached_etag_url == url:
+        headers["If-None-Match"] = cached_etag
+
     try:
         with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-            resp = client.get(url, headers=_build_headers())
+            resp = client.get(url, headers=headers)
+            if resp.status_code == 304:
+                debug("auto-update: 304 Not Modified (etag cache hit)")
+                return (
+                    UpdateInfo(
+                        current_commit=current_commit,
+                        latest_commit=current_commit,
+                        update_available=False,
+                    ),
+                    cached_etag,
+                )
             resp.raise_for_status()
             data = resp.json()
+            new_etag = resp.headers.get("etag") or resp.headers.get("ETag")
     except httpx.HTTPStatusError as exc:
         raise _classify_http_error(exc) from exc
     except httpx.HTTPError as exc:
@@ -450,59 +498,45 @@ def check_for_update(
     except ValueError as exc:
         raise UpdateCheckError(REASON_PARSE_ERROR, str(exc)) from exc
 
-    if not isinstance(data, dict):
+    if not isinstance(data, list):
         raise UpdateCheckError(
-            REASON_PARSE_ERROR, "compare response is not an object"
+            REASON_PARSE_ERROR, "commits response is not a list"
+        )
+    if not data:
+        # Should never happen for a real repo with files under CLI_SUBDIR,
+        # but handle it defensively rather than raising.
+        return (
+            UpdateInfo(
+                current_commit=current_commit,
+                latest_commit=current_commit,
+                update_available=False,
+            ),
+            new_etag,
         )
 
-    ahead_by = data.get("ahead_by", 0)
-    if not isinstance(ahead_by, int) or ahead_by <= 0:
-        return UpdateInfo(
-            current_commit=current_commit,
-            latest_commit=current_commit,
-            update_available=False,
-        )
-
-    changed_files = [
-        str(f.get("filename", ""))
-        for f in data.get("files", [])
-        if isinstance(f, dict)
-    ]
-    cli_changes = [f for f in changed_files if _is_cli_path(f)]
-    if not cli_changes:
-        return UpdateInfo(
-            current_commit=current_commit,
-            latest_commit=current_commit,
-            update_available=False,
-            changed_files=changed_files,
-        )
-
-    commits = data.get("commits", [])
-    if not isinstance(commits, list) or not commits:
+    head = data[0]
+    if not isinstance(head, dict):
         raise UpdateCheckError(
-            REASON_PARSE_ERROR, "compare response missing 'commits' list"
+            REASON_PARSE_ERROR, "commits[0] is not an object"
         )
-
-    newest = _newest_cli_commit(commits)
-    if newest is None:
-        # ``ahead_by`` and ``files`` disagreed with the per-commit view
-        # (rare: GitHub may omit per-commit ``files`` for very large
-        # diffs). Fall back to the tip of ``head`` so the user still
-        # learns that *something* has changed.
-        tip = commits[-1]
-        latest_sha = str(tip.get("sha", ""))[:8]
-        latest_date = (
-            tip.get("commit", {}).get("committer", {}).get("date", "")
+    sha = head.get("sha", "")
+    if not isinstance(sha, str) or not sha:
+        raise UpdateCheckError(
+            REASON_PARSE_ERROR, "commits[0].sha missing or invalid"
         )
-    else:
-        latest_sha, latest_date = newest
+    latest_sha = sha[:8]
+    latest_date = (
+        head.get("commit", {}).get("committer", {}).get("date", "")
+    )
 
-    return UpdateInfo(
-        current_commit=current_commit,
-        latest_commit=latest_sha,
-        latest_commit_date=latest_date or "",
-        update_available=latest_sha != current_commit,
-        changed_files=cli_changes,
+    return (
+        UpdateInfo(
+            current_commit=current_commit,
+            latest_commit=latest_sha,
+            latest_commit_date=str(latest_date) if latest_date else "",
+            update_available=latest_sha != current_commit,
+        ),
+        new_etag,
     )
 
 
@@ -513,13 +547,15 @@ def fetch_update_info(
 
     Returns ``None`` on any error. Use :func:`check_for_update` directly
     when you need the failure category (e.g. to prompt for authentication
-    on rate-limit failures).
+    on rate-limit failures) or want to participate in the etag-cache
+    protocol.
     """
     try:
-        return check_for_update(current_commit, timeout=timeout)
+        info, _ = check_for_update(current_commit, timeout=timeout)
     except UpdateCheckError as exc:
         debug(f"auto-update: check failed [{exc.reason}]: {exc.detail}")
         return None
+    return info
 
 
 # ---------------------------------------------------------------------------
@@ -528,13 +564,31 @@ def fetch_update_info(
 
 
 def _refresh_cache_worker() -> None:
-    """Daemon-thread worker: refresh the cache and never raise."""
+    """Daemon-thread worker: refresh the cache and never raise.
+
+    Participates in the etag protocol so subsequent refreshes can use
+    ``If-None-Match`` and exchange ~200-byte 304 responses with the
+    server when nothing has changed.
+    """
     try:
         current = get_build_commit()
-        info = fetch_update_info(current)
-        if info is None:
-            return
         state = load_cache()
+        upstream_ref = os.environ.get(ENV_UPDATE_REF) or DEFAULT_BRANCH
+        upstream_repo = (
+            os.environ.get(ENV_UPDATE_REPO) or f"{REPO_OWNER}/{REPO_NAME}"
+        )
+        url_for_etag = _build_commits_url(
+            owner_repo=upstream_repo, ref=upstream_ref
+        )
+        try:
+            info, new_etag = check_for_update(
+                current,
+                cached_etag=state.etag,
+                cached_etag_url=state.etag_url,
+            )
+        except UpdateCheckError as exc:
+            debug(f"auto-update: background check failed [{exc.reason}]")
+            return
         # Invalidate the "already-notified" memo when the user has
         # upgraded since the last check, so we don't suppress new
         # legitimate notifications for the *next* release.
@@ -544,6 +598,9 @@ def _refresh_cache_worker() -> None:
         state.latest_commit = info.latest_commit
         state.latest_commit_date = info.latest_commit_date or None
         state.current_at_check = current
+        if new_etag:
+            state.etag = new_etag
+            state.etag_url = url_for_etag
         save_cache(state)
     except Exception as exc:  # pragma: no cover - defensive
         debug(f"auto-update: background refresh crashed: {exc}")

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
@@ -18,9 +18,12 @@ Note: Azure CLI (`az`) must be authenticated; token acquisition uses `az account
 
 from __future__ import annotations
 
+import atexit
+
 import typer
 
 from discovery._version import get_version_string
+from discovery.common.auto_update import maybe_notify, schedule_check
 from discovery.common.logging import set_level
 
 # Re-export from build_acr_task for tests
@@ -45,6 +48,7 @@ from .cli_smoke import app as smoke_test_app
 from .cli_status import app as status_app
 from .cli_storage import app as storage_app
 from .cli_submit import app as submit_app
+from .cli_update import app as update_app
 
 # Re-export API functions for tests
 from .dataplane_api import (  # noqa: F401
@@ -74,9 +78,23 @@ app.add_typer(smoke_app, name="smoke")
 set_level("INFO")
 
 
+def _arm_auto_update() -> None:
+    """Schedule a background update check and queue an at-exit notice.
+
+    Extracted so it can be invoked from both the root callback and the
+    eager ``--version`` handler — Typer raises ``typer.Exit`` from eager
+    callbacks before the main callback body has a chance to run, which
+    would otherwise suppress notifications for users who only run
+    ``discovery --version``.
+    """
+    schedule_check()
+    atexit.register(maybe_notify)
+
+
 def _version_callback(value: bool) -> None:
     """Print version and exit when --version is passed."""
     if value:
+        _arm_auto_update()
         typer.echo(f"discovery {get_version_string()}")
         raise typer.Exit()
 
@@ -100,12 +118,20 @@ def _root_callback(
     """Global options applied before any subcommand executes."""
     if verbose:
         set_level("DEBUG")
+    # Auto-update: spawn a daemon thread to refresh the cache when stale
+    # and queue a notification for after the command finishes. Both are
+    # no-ops when opted out, when not installed via ``uv tool``, or when
+    # the cache is already fresh.
+    _arm_auto_update()
 
 # Register configure command
 app.command(name="configure")(configure_app.registered_commands[0].callback)
 
 # Register doctor command
 app.command(name="doctor")(doctor_app.registered_commands[0].callback)
+
+# Register update command
+app.command(name="update")(update_app.registered_commands[0].callback)
 
 # ---------------------------------------------------------------------------
 # Command groups (alternative organization)

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_doctor.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_doctor.py
@@ -24,6 +24,12 @@ from rich.console import Console
 from rich.table import Table
 
 from discovery._version import get_build_commit, get_version_string
+from discovery.common.auto_update import (
+    CHECK_INTERVAL_HOURS,
+    cache_is_stale,
+    is_opted_out,
+    load_cache,
+)
 from discovery.common.paths import get_config_file_path
 from discovery.poll.az_extensions import check_required_extensions
 
@@ -36,6 +42,7 @@ console = Console()
 _EXPECTED_MODULES = [
     "discovery",
     "discovery.common",
+    "discovery.common.auto_update",
     "discovery.common.config",
     "discovery.common.logging",
     "discovery.poll",
@@ -53,6 +60,7 @@ _EXPECTED_MODULES = [
     "discovery.poll.cli_status",
     "discovery.poll.cli_storage",
     "discovery.poll.cli_submit",
+    "discovery.poll.cli_update",
     "discovery.poll.dataplane_api",
     "discovery.poll.deploy_dataasset",
     "discovery.poll.deploy_tooldef",
@@ -218,6 +226,39 @@ def _render_az_extensions_section() -> bool:
     return True
 
 
+def _render_update_check_section() -> None:
+    """Render the auto-update checker status.
+
+    Informational only — never fails the doctor exit code. Surfaces
+    whether checks are enabled, when the cache was last refreshed, and
+    whether a newer release is currently pending.
+    """
+    state = load_cache()
+    if is_opted_out(state):
+        console.print(
+            "  [yellow]![/yellow] Update checks: [yellow]disabled[/yellow] "
+            "(use `discovery update --enable`)"
+        )
+        return
+
+    last = state.last_checked or "never"
+    if state.last_checked and cache_is_stale(state):
+        last = f"{last} [yellow](stale; >{CHECK_INTERVAL_HOURS}h ago)[/yellow]"
+    console.print(f"  Update checks last refreshed: {last}")
+
+    current = get_build_commit()
+    if state.latest_commit and state.latest_commit != current:
+        console.print(
+            f"  [yellow]![/yellow] Update available: "
+            f"[green]{state.latest_commit}[/green] "
+            f"(run `discovery update` to install)"
+        )
+    elif state.latest_commit:
+        console.print(
+            f"  [green]✓[/green] CLI is up to date ({current})"
+        )
+
+
 @app.command(name="doctor")
 def doctor_command() -> None:
     """Check installation health and report diagnostics."""
@@ -280,6 +321,11 @@ def doctor_command() -> None:
     # surfaces the situation early with an actionable hint.
     if not _render_az_extensions_section():
         all_ok = False
+
+    # Update-checker status: surface the cached state so users can see
+    # whether automatic update notifications will fire and when the
+    # cache was last refreshed.
+    _render_update_check_section()
 
     console.print()
     if all_ok:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
@@ -173,10 +173,10 @@ def update_command(
 ) -> None:
     """Check for a newer Discovery CLI release and optionally install it.
 
-    The check hits the GitHub compare API for the
-    ``microsoft/discovery`` repository's ``main`` branch and reports an
-    update only when the CLI subdirectory has actually changed since the
-    installed build.
+    The check queries the GitHub commits API for the
+    ``microsoft/discovery`` repository's ``main`` branch (filtered to
+    the CLI subdirectory) and reports an update only when the CLI
+    itself has new commits since the installed build.
     """
     _handle_toggles(enable=enable, disable=disable)
 
@@ -190,8 +190,12 @@ def update_command(
 
     console.print("Checking for updates…")
     current = get_build_commit()
+    # Manual `discovery update` invocations always bypass the etag
+    # cache: the user explicitly asked, so we want a fresh answer
+    # rather than a "304 — same as last time" reply that depends on a
+    # potentially-out-of-date local cache.
     try:
-        info = check_for_update(current)
+        info, _ = check_for_update(current)
     except UpdateCheckError as exc:
         _emit_failure(exc)
         raise typer.Exit(code=EXIT_NETWORK) from exc

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
@@ -19,9 +19,10 @@ from rich.console import Console
 from discovery._version import get_build_commit, get_version_string
 from discovery.common.auto_update import (
     UPGRADE_COMMAND,
+    UpdateCheckError,
     UpdateInfo,
     UpgradeError,
-    fetch_update_info,
+    check_for_update,
     install_update,
     is_opted_out,
     load_cache,
@@ -43,6 +44,45 @@ EXIT_NETWORK = 3
 def _emit_status_line() -> None:
     """Print the one-line "current version" header used by all subcommands."""
     console.print(f"Current version: [cyan]{get_version_string()}[/cyan]")
+
+
+_FAILURE_HINTS: dict[str, str] = {
+    "rate_limited": (
+        "GitHub's anonymous API rate limit (60/hour) was exhausted. "
+        "Set [bold]GITHUB_TOKEN[/bold] or run [bold]`gh auth login`[/bold] "
+        "to raise the limit to 5000/hour, then retry."
+    ),
+    "unauthorized": (
+        "GitHub rejected the request (401/403). If the repository is "
+        "private, run [bold]`gh auth login`[/bold] or set "
+        "[bold]GITHUB_TOKEN[/bold] to a token with `repo` scope."
+    ),
+    "not_found": (
+        "GitHub returned 404 — the installed commit may have been "
+        "force-pushed away from the upstream branch, or "
+        "[bold]DISCOVERY_UPDATE_REPO[/bold]/[bold]DISCOVERY_UPDATE_REF[/bold] "
+        "may point at a non-existent ref."
+    ),
+    "network": (
+        "Network error reaching api.github.com. Check connectivity, "
+        "proxy configuration, and DNS, then retry."
+    ),
+    "http_error": "GitHub returned an unexpected HTTP error.",
+    "parse_error": "GitHub returned an unexpected response shape.",
+    "ineligible": (
+        "This build does not report a commit SHA (likely a local-dev "
+        "install); update checks are skipped."
+    ),
+}
+
+
+def _emit_failure(exc: UpdateCheckError) -> None:
+    """Print a tailored, actionable error for ``exc`` and exit."""
+    hint = _FAILURE_HINTS.get(exc.reason, "Update check failed.")
+    console.print(f"[red]Could not check for updates ({exc.reason}).[/red]")
+    console.print(f"  {hint}")
+    if exc.detail:
+        console.print(f"  [dim]Detail: {exc.detail}[/dim]")
 
 
 def _handle_toggles(*, enable: bool, disable: bool) -> None:
@@ -150,15 +190,11 @@ def update_command(
 
     console.print("Checking for updates…")
     current = get_build_commit()
-    info = fetch_update_info(current)
-
-    if info is None:
-        console.print(
-            "[red]Could not reach GitHub.[/red] The `microsoft/discovery` "
-            "repository is private, so the update check requires a token. "
-            "Try [bold]`gh auth login`[/bold] or set `GITHUB_TOKEN` and rerun."
-        )
-        raise typer.Exit(code=EXIT_NETWORK)
+    try:
+        info = check_for_update(current)
+    except UpdateCheckError as exc:
+        _emit_failure(exc)
+        raise typer.Exit(code=EXIT_NETWORK) from exc
 
     if not info.update_available:
         _report_up_to_date(current, info)

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_update.py
@@ -1,0 +1,182 @@
+"""``discovery update`` — check for and install CLI updates.
+
+Mirrors the GitHub Copilot CLI's ``/update`` command. The command is a
+thin Typer wrapper around helpers in :mod:`discovery.common.auto_update`.
+
+Usage:
+    discovery update              # check + interactive install
+    discovery update --check      # check only; never install
+    discovery update -y           # install without confirmation
+    discovery update --disable    # turn off automatic background checks
+    discovery update --enable     # turn them back on
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from discovery._version import get_build_commit, get_version_string
+from discovery.common.auto_update import (
+    UPGRADE_COMMAND,
+    UpdateInfo,
+    UpgradeError,
+    fetch_update_info,
+    install_update,
+    is_opted_out,
+    load_cache,
+    save_cache,
+    set_disabled,
+)
+
+
+app = typer.Typer(help="Check for and install Discovery CLI updates")
+console = Console()
+
+
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_BAD_USAGE = 2
+EXIT_NETWORK = 3
+
+
+def _emit_status_line() -> None:
+    """Print the one-line "current version" header used by all subcommands."""
+    console.print(f"Current version: [cyan]{get_version_string()}[/cyan]")
+
+
+def _handle_toggles(*, enable: bool, disable: bool) -> None:
+    """Apply --enable/--disable; exit early when either flag is set."""
+    if enable and disable:
+        console.print("[red]--enable and --disable are mutually exclusive.[/red]")
+        raise typer.Exit(code=EXIT_BAD_USAGE)
+    if disable:
+        set_disabled(True)
+        console.print(
+            "[yellow]Automatic update checks disabled.[/yellow] "
+            "Re-enable with `discovery update --enable`."
+        )
+        raise typer.Exit(code=EXIT_OK)
+    if enable:
+        set_disabled(False)
+        console.print("[green]Automatic update checks re-enabled.[/green]")
+        raise typer.Exit(code=EXIT_OK)
+
+
+def _report_up_to_date(current: str, info: UpdateInfo) -> None:
+    """Print 'up to date' and refresh the cache baseline."""
+    console.print(f"[green]You are on the latest version[/green] ({current}).")
+    state = load_cache()
+    state.latest_commit = info.latest_commit
+    state.latest_commit_date = info.latest_commit_date or None
+    state.current_at_check = current
+    state.notified_commit = None
+    save_cache(state)
+
+
+def _report_available(current: str, info: UpdateInfo) -> None:
+    """Print the 'update available' summary lines."""
+    date_part = ""
+    if info.latest_commit_date:
+        date_part = f" ({info.latest_commit_date.split('T')[0]})"
+    console.print(
+        f"Update available: [green]{info.latest_commit}[/green]{date_part}"
+    )
+    console.print(f"Installed:      [cyan]{current}[/cyan]")
+
+
+def _apply_install(latest_commit: str) -> None:
+    """Run ``uv tool upgrade discovery`` and baseline the cache on success."""
+    try:
+        rc = install_update()
+    except UpgradeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=EXIT_FAILURE) from exc
+    if rc != 0:
+        console.print(
+            f"[red]`{UPGRADE_COMMAND}` exited with status {rc}.[/red]"
+        )
+        raise typer.Exit(code=rc)
+    state = load_cache()
+    state.notified_commit = latest_commit
+    state.current_at_check = latest_commit
+    save_cache(state)
+    console.print(
+        "[bold green]✓ Discovery CLI upgraded.[/bold green] "
+        "Re-run your command to pick up the new version."
+    )
+
+
+@app.command(name="update")
+def update_command(
+    check: bool = typer.Option(
+        False,
+        "--check",
+        help="Only check for updates; do not install even if one is available.",
+    ),
+    enable: bool = typer.Option(
+        False,
+        "--enable",
+        help="Re-enable automatic background update checks.",
+    ),
+    disable: bool = typer.Option(
+        False,
+        "--disable",
+        help="Disable automatic background update checks (persists across runs).",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Apply the update without an interactive confirmation prompt.",
+    ),
+) -> None:
+    """Check for a newer Discovery CLI release and optionally install it.
+
+    The check hits the GitHub compare API for the
+    ``microsoft/discovery`` repository's ``main`` branch and reports an
+    update only when the CLI subdirectory has actually changed since the
+    installed build.
+    """
+    _handle_toggles(enable=enable, disable=disable)
+
+    _emit_status_line()
+
+    if is_opted_out():
+        console.print(
+            "[yellow]Note:[/yellow] background checks are disabled but a "
+            "manual check will still run."
+        )
+
+    console.print("Checking for updates…")
+    current = get_build_commit()
+    info = fetch_update_info(current)
+
+    if info is None:
+        console.print(
+            "[red]Could not reach GitHub.[/red] The `microsoft/discovery` "
+            "repository is private, so the update check requires a token. "
+            "Try [bold]`gh auth login`[/bold] or set `GITHUB_TOKEN` and rerun."
+        )
+        raise typer.Exit(code=EXIT_NETWORK)
+
+    if not info.update_available:
+        _report_up_to_date(current, info)
+        raise typer.Exit(code=EXIT_OK)
+
+    _report_available(current, info)
+
+    if check:
+        console.print("Run `discovery update` to install.")
+        raise typer.Exit(code=EXIT_OK)
+
+    if not yes and not typer.confirm(
+        f"Install now via `{UPGRADE_COMMAND}`?", default=True
+    ):
+        console.print("[dim]Upgrade skipped.[/dim]")
+        raise typer.Exit(code=EXIT_OK)
+
+    _apply_install(info.latest_commit)
+
+
+__all__ = ["app", "update_command"]

--- a/utilities/supercomputer-cli/discovery/tests/conftest.py
+++ b/utilities/supercomputer-cli/discovery/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from discovery.common import auto_update
 from discovery.common import logging as disc_logging
 
 
@@ -24,3 +25,15 @@ def reset_logging_console():
     yield
     disc_logging._STATE.console = None
     disc_logging._STATE.file_logger = None
+
+
+@pytest.fixture(autouse=True)
+def disable_auto_update_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable real network update checks during tests.
+
+    Tests that exercise the auto-update code paths should mock the
+    relevant helpers explicitly. This autouse fixture guarantees that
+    no test accidentally hits ``api.github.com`` simply because it
+    invokes the CLI through Typer's ``CliRunner``.
+    """
+    monkeypatch.setenv(auto_update.ENV_OPT_OUT, "1")

--- a/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
@@ -405,7 +405,12 @@ class TestFetchUpdateInfo:
         cm.__enter__.return_value = client
         cm.__exit__.return_value = False
         monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        # Silent-failure wrapper returns None.
         assert auto_update.fetch_update_info("deadbeef") is None
+        # Typed wrapper raises the categorized error.
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "network"
 
     def test_returns_none_on_http_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -414,12 +419,80 @@ class TestFetchUpdateInfo:
             httpx, "Client", _patch_httpx_get({}, status=500)
         )
         assert auto_update.fetch_update_info("deadbeef") is None
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "http_error"
+
+    def test_classifies_rate_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 403
+        response.headers = {"x-ratelimit-remaining": "0"}
+        response.text = (
+            '{"message": "API rate limit exceeded for 1.2.3.4."}'
+        )
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "rate", request=MagicMock(), response=response
+        )
+        client = MagicMock()
+        client.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "rate_limited"
+
+    def test_classifies_unauthorized(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 401
+        response.headers = {}
+        response.text = '{"message": "Bad credentials"}'
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "auth", request=MagicMock(), response=response
+        )
+        client = MagicMock()
+        client.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "unauthorized"
+
+    def test_classifies_not_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 404
+        response.headers = {}
+        response.text = '{"message": "Not Found"}'
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=response
+        )
+        client = MagicMock()
+        client.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "not_found"
 
     def test_returns_none_on_invalid_json(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(httpx, "Client", _patch_httpx_get(None))
         assert auto_update.fetch_update_info("deadbeef") is None
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "parse_error"
 
     def test_picks_newest_cli_commit_among_mixed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
@@ -1,0 +1,792 @@
+"""Tests for :mod:`discovery.common.auto_update`."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from discovery.common import auto_update
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the cache directory at a tmp path for the duration of a test."""
+    monkeypatch.setattr(
+        "discovery.common.auto_update.get_home_dir",
+        lambda: tmp_path,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def installed_build(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Pretend we are running a real ``uv tool``-installed build (commit != dev)."""
+    sha = "deadbeef"
+    monkeypatch.setattr(
+        "discovery.common.auto_update.get_build_commit",
+        lambda: sha,
+    )
+    return sha
+
+
+@pytest.fixture
+def enable_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo the conftest autouse opt-out for tests that need to verify the path."""
+    monkeypatch.delenv(auto_update.ENV_OPT_OUT, raising=False)
+
+
+def _compare_response(
+    *,
+    ahead_by: int = 1,
+    cli_filename: str = "utilities/supercomputer-cli/discovery/foo.py",
+    extra_filename: str | None = None,
+    commit_sha: str = "1234567890abcdef1234567890abcdef12345678",
+    commit_date: str = "2025-05-30T12:00:00Z",
+) -> dict:
+    """Build a minimal compare-API payload for use in tests."""
+    files = [{"filename": cli_filename, "status": "modified"}]
+    if extra_filename is not None:
+        files.append({"filename": extra_filename, "status": "modified"})
+    return {
+        "ahead_by": ahead_by,
+        "behind_by": 0,
+        "status": "behind" if ahead_by else "identical",
+        "files": files,
+        "commits": [
+            {
+                "sha": commit_sha,
+                "commit": {"committer": {"date": commit_date}},
+                "files": files,
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache load / save round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCacheIO:
+    def test_load_returns_empty_when_missing(self, fake_home: Path) -> None:
+        state = auto_update.load_cache()
+        assert state == auto_update.UpdateCacheState()
+
+    def test_round_trip_preserves_all_fields(self, fake_home: Path) -> None:
+        original = auto_update.UpdateCacheState(
+            last_checked="2025-05-31T00:00:00+00:00",
+            latest_commit="abcd1234",
+            latest_commit_date="2025-05-30T12:00:00Z",
+            current_at_check="11112222",
+            notified_commit="abcd1234",
+            disabled=True,
+        )
+        auto_update.save_cache(original)
+        loaded = auto_update.load_cache()
+        assert loaded == original
+
+    def test_load_ignores_unknown_keys(self, fake_home: Path) -> None:
+        path = auto_update._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"latest_commit": "feedface", "unknown_future_key": 42}),
+            encoding="utf-8",
+        )
+        loaded = auto_update.load_cache()
+        assert loaded.latest_commit == "feedface"
+
+    def test_load_returns_empty_on_corrupt_json(self, fake_home: Path) -> None:
+        path = auto_update._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json}", encoding="utf-8")
+        assert auto_update.load_cache() == auto_update.UpdateCacheState()
+
+    def test_load_returns_empty_when_top_level_not_dict(
+        self, fake_home: Path
+    ) -> None:
+        path = auto_update._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        assert auto_update.load_cache() == auto_update.UpdateCacheState()
+
+    def test_save_creates_parent_directory(self, fake_home: Path) -> None:
+        nested = fake_home / "deeply" / "nested"
+        with patch(
+            "discovery.common.auto_update.get_home_dir",
+            return_value=nested,
+        ):
+            auto_update.save_cache(
+                auto_update.UpdateCacheState(latest_commit="x")
+            )
+            assert (nested / auto_update.CACHE_DIR_NAME / auto_update.CACHE_FILE_NAME).exists()
+
+
+# ---------------------------------------------------------------------------
+# Opt-out + staleness
+# ---------------------------------------------------------------------------
+
+
+class TestOptOut:
+    def test_env_var_opts_out(
+        self, monkeypatch: pytest.MonkeyPatch, fake_home: Path
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_OPT_OUT, "1")
+        assert auto_update.is_opted_out() is True
+
+    def test_env_var_falsy_does_not_opt_out(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        enable_checks: None,
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_OPT_OUT, "")
+        assert auto_update.is_opted_out() is False
+
+    def test_disabled_flag_opts_out(
+        self, fake_home: Path, enable_checks: None
+    ) -> None:
+        auto_update.set_disabled(True)
+        assert auto_update.is_opted_out() is True
+
+    def test_set_disabled_round_trip(
+        self, fake_home: Path, enable_checks: None
+    ) -> None:
+        auto_update.set_disabled(True)
+        assert auto_update.load_cache().disabled is True
+        auto_update.set_disabled(False)
+        assert auto_update.load_cache().disabled is False
+
+
+class TestCacheIsStale:
+    def test_empty_cache_is_stale(self) -> None:
+        assert auto_update.cache_is_stale(auto_update.UpdateCacheState())
+
+    def test_fresh_cache_not_stale(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        now = datetime(2025, 5, 31, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("discovery.common.auto_update._now", lambda: now)
+        state = auto_update.UpdateCacheState(
+            last_checked=(now - timedelta(hours=1)).isoformat()
+        )
+        assert auto_update.cache_is_stale(state) is False
+
+    def test_old_cache_is_stale(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = datetime(2025, 5, 31, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("discovery.common.auto_update._now", lambda: now)
+        state = auto_update.UpdateCacheState(
+            last_checked=(now - timedelta(hours=48)).isoformat()
+        )
+        assert auto_update.cache_is_stale(state) is True
+
+    def test_unparseable_timestamp_is_stale(self) -> None:
+        state = auto_update.UpdateCacheState(last_checked="not a date")
+        assert auto_update.cache_is_stale(state) is True
+
+
+# ---------------------------------------------------------------------------
+# Eligibility
+# ---------------------------------------------------------------------------
+
+
+class TestShouldCheck:
+    def test_dev_install_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.get_build_commit",
+            lambda: auto_update.DEV_COMMIT_SENTINEL,
+        )
+        assert auto_update._should_check() is False
+
+    def test_real_install_eligible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.get_build_commit",
+            lambda: "abc12345",
+        )
+        assert auto_update._should_check() is True
+
+
+# ---------------------------------------------------------------------------
+# fetch_update_info
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx_get(payload: dict | None, *, status: int = 200) -> MagicMock:
+    """Return a context-manager mock that yields a client whose .get(...) returns ``payload``."""
+    response = MagicMock()
+    response.status_code = status
+    if payload is None:
+        response.json.side_effect = ValueError("no body")
+    else:
+        response.json.return_value = payload
+    if status >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+
+    client = MagicMock()
+    client.get.return_value = response
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = False
+    return MagicMock(return_value=cm)
+
+
+class TestFetchUpdateInfo:
+    def test_returns_none_for_dev_commit(self) -> None:
+        assert (
+            auto_update.fetch_update_info(auto_update.DEV_COMMIT_SENTINEL)
+            is None
+        )
+
+    def test_returns_none_for_empty_commit(self) -> None:
+        assert auto_update.fetch_update_info("") is None
+
+    def test_reports_update_when_cli_dir_changed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = _compare_response(
+            commit_sha="abcdef1234567890abcdef1234567890abcdef12",
+            commit_date="2025-06-01T08:00:00Z",
+        )
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
+        info = auto_update.fetch_update_info("deadbeef")
+        assert info is not None
+        assert info.update_available is True
+        assert info.latest_commit == "abcdef12"
+        assert info.latest_commit_date == "2025-06-01T08:00:00Z"
+        assert info.current_commit == "deadbeef"
+
+    def test_sends_authorization_header_when_token_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = _compare_response()
+        client_mock = MagicMock()
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        client_mock.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client_mock
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        monkeypatch.setenv("DISCOVERY_GITHUB_TOKEN", "secret-token")
+
+        auto_update.fetch_update_info("deadbeef")
+
+        sent_headers = client_mock.get.call_args.kwargs["headers"]
+        assert sent_headers["Authorization"] == "Bearer secret-token"
+
+    def test_no_authorization_header_when_no_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in auto_update.TOKEN_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        # Stub out gh CLI lookup so the test doesn't depend on the
+        # developer's local `gh auth` state.
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: None
+        )
+        payload = _compare_response()
+        client_mock = MagicMock()
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        client_mock.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client_mock
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        auto_update.fetch_update_info("deadbeef")
+        sent_headers = client_mock.get.call_args.kwargs["headers"]
+        assert "Authorization" not in sent_headers
+
+    def test_reports_no_update_when_no_cli_changes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = _compare_response(
+            cli_filename="agents/some-agent/metadata.yaml",
+        )
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
+        info = auto_update.fetch_update_info("deadbeef")
+        assert info is not None
+        assert info.update_available is False
+        assert info.latest_commit == "deadbeef"
+
+    def test_reports_no_update_when_ahead_by_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = _compare_response(ahead_by=0)
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
+        info = auto_update.fetch_update_info("deadbeef")
+        assert info is not None
+        assert info.update_available is False
+
+    def test_returns_none_on_network_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = MagicMock()
+        client.get.side_effect = httpx.ConnectError("no network")
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+        assert auto_update.fetch_update_info("deadbeef") is None
+
+    def test_returns_none_on_http_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            httpx, "Client", _patch_httpx_get({}, status=500)
+        )
+        assert auto_update.fetch_update_info("deadbeef") is None
+
+    def test_returns_none_on_invalid_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(None))
+        assert auto_update.fetch_update_info("deadbeef") is None
+
+    def test_picks_newest_cli_commit_among_mixed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 3 commits: oldest CLI, middle unrelated, newest unrelated.
+        # Newest CLI-touching should win even though it's not the tip.
+        payload = {
+            "ahead_by": 3,
+            "files": [
+                {"filename": "utilities/supercomputer-cli/discovery/x.py"},
+                {"filename": "agents/other/README.md"},
+            ],
+            "commits": [
+                {
+                    "sha": "111111111111111111",
+                    "commit": {"committer": {"date": "2025-01-01T00:00:00Z"}},
+                    "files": [
+                        {"filename": "utilities/supercomputer-cli/discovery/x.py"}
+                    ],
+                },
+                {
+                    "sha": "222222222222222222",
+                    "commit": {"committer": {"date": "2025-02-01T00:00:00Z"}},
+                    "files": [
+                        {"filename": "utilities/supercomputer-cli/discovery/y.py"}
+                    ],
+                },
+                {
+                    "sha": "333333333333333333",
+                    "commit": {"committer": {"date": "2025-03-01T00:00:00Z"}},
+                    "files": [{"filename": "agents/other/README.md"}],
+                },
+            ],
+        }
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
+        info = auto_update.fetch_update_info("deadbeef")
+        assert info is not None
+        assert info.latest_commit == "22222222"
+
+    def test_falls_back_to_tip_when_per_commit_files_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {
+            "ahead_by": 1,
+            "files": [
+                {"filename": "utilities/supercomputer-cli/discovery/x.py"}
+            ],
+            "commits": [
+                {
+                    "sha": "abcdef1234567890",
+                    "commit": {"committer": {"date": "2025-06-01T00:00:00Z"}},
+                }
+            ],
+        }
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
+        info = auto_update.fetch_update_info("deadbeef")
+        assert info is not None
+        assert info.latest_commit == "abcdef12"
+        assert info.update_available is True
+
+
+class TestTokenResolution:
+    def test_env_var_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISCOVERY_GITHUB_TOKEN", "from-discovery")
+        monkeypatch.setenv("GITHUB_TOKEN", "from-github")
+        assert auto_update._resolve_github_token() == "from-discovery"
+
+    def test_falls_back_to_github_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DISCOVERY_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "from-github")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        assert auto_update._resolve_github_token() == "from-github"
+
+    def test_falls_back_to_gh_cli_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in auto_update.TOKEN_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which",
+            lambda _: "/usr/local/bin/gh",
+        )
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = "ghp_fakefakefakefake\n"
+        monkeypatch.setattr(
+            "discovery.common.auto_update.subprocess.run",
+            MagicMock(return_value=proc),
+        )
+        assert auto_update._resolve_github_token() == "ghp_fakefakefakefake"
+
+    def test_returns_none_when_no_token_anywhere(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in auto_update.TOKEN_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: None
+        )
+        assert auto_update._resolve_github_token() is None
+
+    def test_gh_cli_failure_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in auto_update.TOKEN_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which",
+            lambda _: "/usr/local/bin/gh",
+        )
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stdout = ""
+        monkeypatch.setattr(
+            "discovery.common.auto_update.subprocess.run",
+            MagicMock(return_value=proc),
+        )
+        assert auto_update._resolve_github_token() is None
+
+
+# ---------------------------------------------------------------------------
+# schedule_check
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleCheck:
+    def test_skipped_for_dev_install(
+        self, monkeypatch: pytest.MonkeyPatch, fake_home: Path
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.get_build_commit",
+            lambda: "dev",
+        )
+        assert auto_update.schedule_check() is None
+
+    def test_skipped_when_opted_out_via_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_OPT_OUT, "1")
+        assert auto_update.schedule_check() is None
+
+    def test_skipped_when_cache_fresh(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+        enable_checks: None,
+    ) -> None:
+        now = datetime(2025, 5, 31, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("discovery.common.auto_update._now", lambda: now)
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                last_checked=(now - timedelta(minutes=10)).isoformat()
+            )
+        )
+        assert auto_update.schedule_check() is None
+
+    def test_spawns_thread_when_stale(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+        enable_checks: None,
+    ) -> None:
+        # Stub out the worker so the thread terminates immediately without
+        # hitting the network.
+        called = {"count": 0}
+
+        def stub_worker() -> None:
+            called["count"] += 1
+
+        monkeypatch.setattr(
+            "discovery.common.auto_update._refresh_cache_worker", stub_worker
+        )
+        thread = auto_update.schedule_check()
+        assert thread is not None
+        thread.join(timeout=2)
+        assert called["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Worker behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshCacheWorker:
+    def test_writes_cache_on_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            latest_commit_date="2025-06-01T00:00:00Z",
+            update_available=True,
+        )
+        now = datetime(2025, 6, 1, 9, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.fetch_update_info",
+            lambda *_args, **_kw: info,
+        )
+        monkeypatch.setattr("discovery.common.auto_update._now", lambda: now)
+        auto_update._refresh_cache_worker()
+
+        state = auto_update.load_cache()
+        assert state.latest_commit == "cafef00d"
+        assert state.latest_commit_date == "2025-06-01T00:00:00Z"
+        assert state.current_at_check == installed_build
+        assert state.last_checked == now.isoformat()
+
+    def test_resets_notified_on_upgrade(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        """When the installed commit changes between checks, the
+        ``notified_commit`` memo must be cleared so the next pending
+        update is announced even if it happens to match an old SHA."""
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                current_at_check="oldoldol",
+                notified_commit="cafef00d",
+                latest_commit="cafef00d",
+            )
+        )
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            update_available=True,
+        )
+        monkeypatch.setattr(
+            "discovery.common.auto_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+        auto_update._refresh_cache_worker()
+        state = auto_update.load_cache()
+        assert state.notified_commit is None
+        assert state.current_at_check == installed_build
+
+    def test_no_cache_write_on_network_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.fetch_update_info",
+            lambda *_a, **_k: None,
+        )
+        auto_update._refresh_cache_worker()
+        assert not auto_update._cache_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# maybe_notify
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeNotify:
+    def test_silent_when_no_cache(
+        self,
+        fake_home: Path,
+        installed_build: str,
+        capsys: pytest.CaptureFixture,
+        enable_checks: None,
+    ) -> None:
+        auto_update.maybe_notify()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_silent_when_already_notified(
+        self,
+        fake_home: Path,
+        installed_build: str,
+        capsys: pytest.CaptureFixture,
+        enable_checks: None,
+    ) -> None:
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                latest_commit="newshasx",
+                notified_commit="newshasx",
+            )
+        )
+        auto_update.maybe_notify()
+        assert capsys.readouterr().err == ""
+
+    def test_silent_when_disabled(
+        self,
+        fake_home: Path,
+        installed_build: str,
+        capsys: pytest.CaptureFixture,
+        enable_checks: None,
+    ) -> None:
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                latest_commit="newshasx",
+                disabled=True,
+            )
+        )
+        auto_update.maybe_notify()
+        assert capsys.readouterr().err == ""
+
+    def test_prints_and_marks_notified(
+        self,
+        fake_home: Path,
+        installed_build: str,
+        capsys: pytest.CaptureFixture,
+        enable_checks: None,
+    ) -> None:
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                latest_commit="newshasx",
+                latest_commit_date="2025-06-01T00:00:00Z",
+            )
+        )
+        auto_update.maybe_notify()
+        out = capsys.readouterr().err
+        assert "Discovery CLI" in out
+        assert "newshasx" in out
+        state = auto_update.load_cache()
+        assert state.notified_commit == "newshasx"
+
+    def test_silent_for_dev_build(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        capsys: pytest.CaptureFixture,
+        enable_checks: None,
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.get_build_commit",
+            lambda: "dev",
+        )
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(latest_commit="newshasx")
+        )
+        auto_update.maybe_notify()
+        assert capsys.readouterr().err == ""
+
+
+# ---------------------------------------------------------------------------
+# format_notification
+# ---------------------------------------------------------------------------
+
+
+class TestFormatNotification:
+    def test_includes_all_fields(self) -> None:
+        msg = auto_update.format_notification(
+            "deadbeef", "cafef00d", "2025-06-01T08:00:00Z"
+        )
+        assert "deadbeef" in msg
+        assert "cafef00d" in msg
+        assert "2025-06-01" in msg
+        assert auto_update.UPGRADE_COMMAND in msg
+
+    def test_omits_empty_date(self) -> None:
+        msg = auto_update.format_notification("deadbeef", "cafef00d", "")
+        assert "()" not in msg
+
+
+# ---------------------------------------------------------------------------
+# install_update
+# ---------------------------------------------------------------------------
+
+
+class TestInstallUpdate:
+    def test_raises_when_uv_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: None
+        )
+        with pytest.raises(auto_update.UpgradeError):
+            auto_update.install_update()
+
+    def test_dry_run_does_not_invoke_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: "/usr/bin/uv"
+        )
+        called = MagicMock()
+        monkeypatch.setattr(
+            "discovery.common.auto_update.subprocess.run", called
+        )
+        rc = auto_update.install_update(dry_run=True)
+        assert rc == 0
+        called.assert_not_called()
+
+    def test_runs_uv_tool_upgrade(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: "/usr/bin/uv"
+        )
+        proc = MagicMock()
+        proc.returncode = 0
+        run = MagicMock(return_value=proc)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.subprocess.run", run
+        )
+        rc = auto_update.install_update()
+        assert rc == 0
+        run.assert_called_once_with(
+            ["uv", "tool", "upgrade", "discovery"], check=False
+        )
+
+    def test_returns_nonzero_on_subprocess_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: "/usr/bin/uv"
+        )
+        proc = MagicMock()
+        proc.returncode = 7
+        monkeypatch.setattr(
+            "discovery.common.auto_update.subprocess.run",
+            MagicMock(return_value=proc),
+        )
+        assert auto_update.install_update() == 7

--- a/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
@@ -315,6 +315,66 @@ class TestFetchUpdateInfo:
         sent_headers = client_mock.get.call_args.kwargs["headers"]
         assert "Authorization" not in sent_headers
 
+    def test_uses_default_branch_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(auto_update.ENV_UPDATE_REF, raising=False)
+        payload = _compare_response()
+        client_mock = MagicMock()
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        client_mock.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client_mock
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        auto_update.fetch_update_info("deadbeef")
+        url = client_mock.get.call_args.args[0]
+        assert "...main" in url
+
+    def test_honors_update_ref_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "release/rc-1")
+        payload = _compare_response()
+        client_mock = MagicMock()
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        client_mock.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client_mock
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        auto_update.fetch_update_info("deadbeef")
+        url = client_mock.get.call_args.args[0]
+        assert "...release/rc-1" in url
+        assert "microsoft/discovery" in url
+
+    def test_honors_update_repo_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REPO, "fork-user/discovery")
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "feat/x")
+        payload = _compare_response()
+        client_mock = MagicMock()
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        client_mock.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client_mock
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        auto_update.fetch_update_info("deadbeef")
+        url = client_mock.get.call_args.args[0]
+        assert "repos/fork-user/discovery/compare/" in url
+        assert "...feat/x" in url
+
     def test_reports_no_update_when_no_cli_changes(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_auto_update.py
@@ -45,31 +45,21 @@ def enable_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(auto_update.ENV_OPT_OUT, raising=False)
 
 
-def _compare_response(
+def _commits_response(
     *,
-    ahead_by: int = 1,
-    cli_filename: str = "utilities/supercomputer-cli/discovery/foo.py",
-    extra_filename: str | None = None,
     commit_sha: str = "1234567890abcdef1234567890abcdef12345678",
     commit_date: str = "2025-05-30T12:00:00Z",
-) -> dict:
-    """Build a minimal compare-API payload for use in tests."""
-    files = [{"filename": cli_filename, "status": "modified"}]
-    if extra_filename is not None:
-        files.append({"filename": extra_filename, "status": "modified"})
-    return {
-        "ahead_by": ahead_by,
-        "behind_by": 0,
-        "status": "behind" if ahead_by else "identical",
-        "files": files,
-        "commits": [
-            {
-                "sha": commit_sha,
-                "commit": {"committer": {"date": commit_date}},
-                "files": files,
-            }
-        ],
-    }
+) -> list:
+    """Build a minimal ``GET /commits?path=...&per_page=1`` payload."""
+    return [
+        {
+            "sha": commit_sha,
+            "commit": {
+                "committer": {"date": commit_date},
+                "message": "feat: thing",
+            },
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -222,10 +212,21 @@ class TestShouldCheck:
 # ---------------------------------------------------------------------------
 
 
-def _patch_httpx_get(payload: dict | None, *, status: int = 200) -> MagicMock:
-    """Return a context-manager mock that yields a client whose .get(...) returns ``payload``."""
+
+def _patch_httpx_get(
+    payload: object,
+    *,
+    status: int = 200,
+    response_headers: dict | None = None,
+) -> MagicMock:
+    """Return a context-manager mock that yields a client whose ``.get()``
+    returns the configured response.
+
+    ``payload`` may be a dict, list, or ``None`` (to simulate invalid JSON).
+    """
     response = MagicMock()
     response.status_code = status
+    response.headers = response_headers or {}
     if payload is None:
         response.json.side_effect = ValueError("no body")
     else:
@@ -245,6 +246,31 @@ def _patch_httpx_get(payload: dict | None, *, status: int = 200) -> MagicMock:
     return MagicMock(return_value=cm)
 
 
+def _patch_client_capture(monkeypatch, *, payload=None, headers=None, status=200):
+    """Install an httpx.Client mock and return the inner client mock so the
+    test can inspect what was sent."""
+    response = MagicMock()
+    response.status_code = status
+    response.headers = headers or {}
+    if payload is None:
+        response.json.side_effect = ValueError("no body")
+    else:
+        response.json.return_value = payload
+    if status >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    client = MagicMock()
+    client.get.return_value = response
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = False
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+    return client
+
+
 class TestFetchUpdateInfo:
     def test_returns_none_for_dev_commit(self) -> None:
         assert (
@@ -255,10 +281,10 @@ class TestFetchUpdateInfo:
     def test_returns_none_for_empty_commit(self) -> None:
         assert auto_update.fetch_update_info("") is None
 
-    def test_reports_update_when_cli_dir_changed(
+    def test_reports_update_when_latest_sha_differs(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        payload = _compare_response(
+        payload = _commits_response(
             commit_sha="abcdef1234567890abcdef1234567890abcdef12",
             commit_date="2025-06-01T08:00:00Z",
         )
@@ -270,116 +296,12 @@ class TestFetchUpdateInfo:
         assert info.latest_commit_date == "2025-06-01T08:00:00Z"
         assert info.current_commit == "deadbeef"
 
-    def test_sends_authorization_header_when_token_present(
+    def test_reports_no_update_when_latest_sha_matches(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        payload = _compare_response()
-        client_mock = MagicMock()
-        response = MagicMock()
-        response.json.return_value = payload
-        response.raise_for_status.return_value = None
-        client_mock.get.return_value = response
-        cm = MagicMock()
-        cm.__enter__.return_value = client_mock
-        cm.__exit__.return_value = False
-        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-        monkeypatch.setenv("DISCOVERY_GITHUB_TOKEN", "secret-token")
-
-        auto_update.fetch_update_info("deadbeef")
-
-        sent_headers = client_mock.get.call_args.kwargs["headers"]
-        assert sent_headers["Authorization"] == "Bearer secret-token"
-
-    def test_no_authorization_header_when_no_token(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        for var in auto_update.TOKEN_ENV_VARS:
-            monkeypatch.delenv(var, raising=False)
-        # Stub out gh CLI lookup so the test doesn't depend on the
-        # developer's local `gh auth` state.
-        monkeypatch.setattr(
-            "discovery.common.auto_update.shutil.which", lambda _: None
-        )
-        payload = _compare_response()
-        client_mock = MagicMock()
-        response = MagicMock()
-        response.json.return_value = payload
-        response.raise_for_status.return_value = None
-        client_mock.get.return_value = response
-        cm = MagicMock()
-        cm.__enter__.return_value = client_mock
-        cm.__exit__.return_value = False
-        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-
-        auto_update.fetch_update_info("deadbeef")
-        sent_headers = client_mock.get.call_args.kwargs["headers"]
-        assert "Authorization" not in sent_headers
-
-    def test_uses_default_branch_when_env_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv(auto_update.ENV_UPDATE_REF, raising=False)
-        payload = _compare_response()
-        client_mock = MagicMock()
-        response = MagicMock()
-        response.json.return_value = payload
-        response.raise_for_status.return_value = None
-        client_mock.get.return_value = response
-        cm = MagicMock()
-        cm.__enter__.return_value = client_mock
-        cm.__exit__.return_value = False
-        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-
-        auto_update.fetch_update_info("deadbeef")
-        url = client_mock.get.call_args.args[0]
-        assert "...main" in url
-
-    def test_honors_update_ref_env_var(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "release/rc-1")
-        payload = _compare_response()
-        client_mock = MagicMock()
-        response = MagicMock()
-        response.json.return_value = payload
-        response.raise_for_status.return_value = None
-        client_mock.get.return_value = response
-        cm = MagicMock()
-        cm.__enter__.return_value = client_mock
-        cm.__exit__.return_value = False
-        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-
-        auto_update.fetch_update_info("deadbeef")
-        url = client_mock.get.call_args.args[0]
-        assert "...release/rc-1" in url
-        assert "microsoft/discovery" in url
-
-    def test_honors_update_repo_env_var(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv(auto_update.ENV_UPDATE_REPO, "fork-user/discovery")
-        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "feat/x")
-        payload = _compare_response()
-        client_mock = MagicMock()
-        response = MagicMock()
-        response.json.return_value = payload
-        response.raise_for_status.return_value = None
-        client_mock.get.return_value = response
-        cm = MagicMock()
-        cm.__enter__.return_value = client_mock
-        cm.__exit__.return_value = False
-        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-
-        auto_update.fetch_update_info("deadbeef")
-        url = client_mock.get.call_args.args[0]
-        assert "repos/fork-user/discovery/compare/" in url
-        assert "...feat/x" in url
-
-    def test_reports_no_update_when_no_cli_changes(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        payload = _compare_response(
-            cli_filename="agents/some-agent/metadata.yaml",
+        # Latest commit's short SHA equals "deadbeef" (first 8 chars).
+        payload = _commits_response(
+            commit_sha="deadbeef000000000000000000000000",
         )
         monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
         info = auto_update.fetch_update_info("deadbeef")
@@ -387,14 +309,72 @@ class TestFetchUpdateInfo:
         assert info.update_available is False
         assert info.latest_commit == "deadbeef"
 
-    def test_reports_no_update_when_ahead_by_zero(
+    def test_uses_commits_endpoint_with_path_filter(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        payload = _compare_response(ahead_by=0)
-        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
-        info = auto_update.fetch_update_info("deadbeef")
-        assert info is not None
-        assert info.update_available is False
+        """The fetcher must hit ``/commits?path=…&per_page=1`` — the
+        light endpoint that returns only commit metadata (no per-file
+        diffs)."""
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        url = client.get.call_args.args[0]
+        assert "/commits?" in url
+        assert "path=utilities/supercomputer-cli/" in url
+        assert "per_page=1" in url
+        # And NOT the heavy compare endpoint
+        assert "/compare/" not in url
+
+    def test_sends_authorization_header_when_token_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISCOVERY_GITHUB_TOKEN", "secret-token")
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert sent_headers["Authorization"] == "Bearer secret-token"
+
+    def test_no_authorization_header_when_no_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for var in auto_update.TOKEN_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "discovery.common.auto_update.shutil.which", lambda _: None
+        )
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert "Authorization" not in sent_headers
+
+    def test_uses_default_branch_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(auto_update.ENV_UPDATE_REF, raising=False)
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        url = client.get.call_args.args[0]
+        assert "sha=main&" in url
+
+    def test_honors_update_ref_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "release/rc-1")
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        url = client.get.call_args.args[0]
+        assert "sha=release/rc-1" in url
+        assert "microsoft/discovery" in url
+
+    def test_honors_update_repo_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REPO, "fork-user/discovery")
+        monkeypatch.setenv(auto_update.ENV_UPDATE_REF, "feat/x")
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        auto_update.fetch_update_info("deadbeef")
+        url = client.get.call_args.args[0]
+        assert "repos/fork-user/discovery/commits" in url
+        assert "sha=feat/x" in url
 
     def test_returns_none_on_network_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -405,9 +385,7 @@ class TestFetchUpdateInfo:
         cm.__enter__.return_value = client
         cm.__exit__.return_value = False
         monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
-        # Silent-failure wrapper returns None.
         assert auto_update.fetch_update_info("deadbeef") is None
-        # Typed wrapper raises the categorized error.
         with pytest.raises(auto_update.UpdateCheckError) as ei:
             auto_update.check_for_update("deadbeef")
         assert ei.value.reason == "network"
@@ -494,64 +472,125 @@ class TestFetchUpdateInfo:
             auto_update.check_for_update("deadbeef")
         assert ei.value.reason == "parse_error"
 
-    def test_picks_newest_cli_commit_among_mixed(
+    def test_raises_when_response_is_not_a_list(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # 3 commits: oldest CLI, middle unrelated, newest unrelated.
-        # Newest CLI-touching should win even though it's not the tip.
-        payload = {
-            "ahead_by": 3,
-            "files": [
-                {"filename": "utilities/supercomputer-cli/discovery/x.py"},
-                {"filename": "agents/other/README.md"},
-            ],
-            "commits": [
-                {
-                    "sha": "111111111111111111",
-                    "commit": {"committer": {"date": "2025-01-01T00:00:00Z"}},
-                    "files": [
-                        {"filename": "utilities/supercomputer-cli/discovery/x.py"}
-                    ],
-                },
-                {
-                    "sha": "222222222222222222",
-                    "commit": {"committer": {"date": "2025-02-01T00:00:00Z"}},
-                    "files": [
-                        {"filename": "utilities/supercomputer-cli/discovery/y.py"}
-                    ],
-                },
-                {
-                    "sha": "333333333333333333",
-                    "commit": {"committer": {"date": "2025-03-01T00:00:00Z"}},
-                    "files": [{"filename": "agents/other/README.md"}],
-                },
-            ],
-        }
-        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
-        info = auto_update.fetch_update_info("deadbeef")
-        assert info is not None
-        assert info.latest_commit == "22222222"
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get({"oops": True}))
+        with pytest.raises(auto_update.UpdateCheckError) as ei:
+            auto_update.check_for_update("deadbeef")
+        assert ei.value.reason == "parse_error"
 
-    def test_falls_back_to_tip_when_per_commit_files_missing(
+    def test_empty_commits_list_is_no_update(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        payload = {
-            "ahead_by": 1,
-            "files": [
-                {"filename": "utilities/supercomputer-cli/discovery/x.py"}
-            ],
-            "commits": [
-                {
-                    "sha": "abcdef1234567890",
-                    "commit": {"committer": {"date": "2025-06-01T00:00:00Z"}},
-                }
-            ],
-        }
-        monkeypatch.setattr(httpx, "Client", _patch_httpx_get(payload))
-        info = auto_update.fetch_update_info("deadbeef")
-        assert info is not None
-        assert info.latest_commit == "abcdef12"
+        monkeypatch.setattr(httpx, "Client", _patch_httpx_get([]))
+        info, _ = auto_update.check_for_update("deadbeef")
+        assert info.update_available is False
+
+
+class TestEtagConditionalGet:
+    """The fetcher must use If-None-Match / 304 to avoid bandwidth and
+    rate-limit waste in the steady-state-unchanged case."""
+
+    def test_sends_if_none_match_when_cached_etag_matches_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _patch_client_capture(
+            monkeypatch,
+            payload=_commits_response(),
+            headers={"ETag": 'W/"new-etag-123"'},
+        )
+        url = auto_update._build_commits_url(
+            owner_repo="microsoft/discovery", ref="main"
+        )
+        info, new_etag = auto_update.check_for_update(
+            "deadbeef",
+            cached_etag='W/"prev-etag"',
+            cached_etag_url=url,
+        )
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert sent_headers["If-None-Match"] == 'W/"prev-etag"'
+        assert new_etag == 'W/"new-etag-123"'
         assert info.update_available is True
+
+    def test_skips_if_none_match_when_url_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _patch_client_capture(monkeypatch, payload=_commits_response())
+        # cached_etag_url points at a stale URL (e.g. user changed
+        # DISCOVERY_UPDATE_REF). Fetcher should NOT send the stale etag.
+        auto_update.check_for_update(
+            "deadbeef",
+            cached_etag='W/"stale-etag"',
+            cached_etag_url="https://api.github.com/elsewhere",
+        )
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert "If-None-Match" not in sent_headers
+
+    def test_304_reports_no_update_and_preserves_etag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 304
+        response.headers = {}
+        client = MagicMock()
+        client.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        url = auto_update._build_commits_url(
+            owner_repo="microsoft/discovery", ref="main"
+        )
+        info, new_etag = auto_update.check_for_update(
+            "deadbeef",
+            cached_etag='W/"unchanged"',
+            cached_etag_url=url,
+        )
+        assert info.update_available is False
+        assert info.latest_commit == "deadbeef"
+        # 304: server didn't send a new etag, we keep the cached one
+        # so subsequent requests can keep using it.
+        assert new_etag == 'W/"unchanged"'
+
+    def test_background_worker_uses_etag_protocol(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        """End-to-end: cache an etag, run worker, confirm If-None-Match
+        is sent and the etag persists across the round-trip."""
+        url = auto_update._build_commits_url(
+            owner_repo="microsoft/discovery", ref="main"
+        )
+        auto_update.save_cache(
+            auto_update.UpdateCacheState(
+                etag='W/"prev"',
+                etag_url=url,
+            )
+        )
+
+        response = MagicMock()
+        response.status_code = 304
+        response.headers = {}
+        client = MagicMock()
+        client.get.return_value = response
+        cm = MagicMock()
+        cm.__enter__.return_value = client
+        cm.__exit__.return_value = False
+        monkeypatch.setattr(httpx, "Client", MagicMock(return_value=cm))
+
+        auto_update._refresh_cache_worker()
+        sent_headers = client.get.call_args.kwargs["headers"]
+        assert sent_headers["If-None-Match"] == 'W/"prev"'
+
+        state = auto_update.load_cache()
+        assert state.etag == 'W/"prev"'
+        assert state.etag_url == url
+        # 304 still updated last_checked so the freshness window resets.
+        assert state.last_checked is not None
 
 
 class TestTokenResolution:
@@ -700,8 +739,8 @@ class TestRefreshCacheWorker:
         )
         now = datetime(2025, 6, 1, 9, 0, tzinfo=timezone.utc)
         monkeypatch.setattr(
-            "discovery.common.auto_update.fetch_update_info",
-            lambda *_args, **_kw: info,
+            "discovery.common.auto_update.check_for_update",
+            lambda *_args, **_kw: (info, 'W/"fresh-etag"'),
         )
         monkeypatch.setattr("discovery.common.auto_update._now", lambda: now)
         auto_update._refresh_cache_worker()
@@ -711,6 +750,10 @@ class TestRefreshCacheWorker:
         assert state.latest_commit_date == "2025-06-01T00:00:00Z"
         assert state.current_at_check == installed_build
         assert state.last_checked == now.isoformat()
+        # New etag should be persisted, bound to the URL the worker hit.
+        assert state.etag == 'W/"fresh-etag"'
+        assert state.etag_url is not None
+        assert "/commits?" in state.etag_url
 
     def test_resets_notified_on_upgrade(
         self,
@@ -734,8 +777,8 @@ class TestRefreshCacheWorker:
             update_available=True,
         )
         monkeypatch.setattr(
-            "discovery.common.auto_update.fetch_update_info",
-            lambda *_a, **_k: info,
+            "discovery.common.auto_update.check_for_update",
+            lambda *_a, **_k: (info, None),
         )
         auto_update._refresh_cache_worker()
         state = auto_update.load_cache()
@@ -748,9 +791,13 @@ class TestRefreshCacheWorker:
         fake_home: Path,
         installed_build: str,
     ) -> None:
+        def explode(*_a, **_k):
+            raise auto_update.UpdateCheckError(
+                auto_update.REASON_NETWORK, "down"
+            )
+
         monkeypatch.setattr(
-            "discovery.common.auto_update.fetch_update_info",
-            lambda *_a, **_k: None,
+            "discovery.common.auto_update.check_for_update", explode
         )
         auto_update._refresh_cache_worker()
         assert not auto_update._cache_path().exists()

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
@@ -75,7 +75,7 @@ class TestUpdateCommandCheck:
             update_available=False,
         )
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             lambda *_a, **_k: info,
         )
         result = runner.invoke(app, ["update"])
@@ -95,7 +95,7 @@ class TestUpdateCommandCheck:
             update_available=True,
         )
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             lambda *_a, **_k: info,
         )
         result = runner.invoke(app, ["update", "--check"])
@@ -109,13 +109,41 @@ class TestUpdateCommandCheck:
         fake_home: Path,
         installed_build: str,
     ) -> None:
+        def raise_network(*_a: object, **_k: object) -> None:
+            msg = "DNS failure"
+            raise auto_update.UpdateCheckError(
+                auto_update.REASON_NETWORK, msg
+            )
+
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
-            lambda *_a, **_k: None,
+            "discovery.poll.cli_update.check_for_update",
+            raise_network,
         )
         result = runner.invoke(app, ["update"])
         assert result.exit_code == 3
-        assert "Could not reach GitHub" in result.stdout
+        assert "Could not check for updates" in result.stdout
+        assert "network" in result.stdout
+
+    def test_rate_limit_message_offers_token_hint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        def raise_rate(*_a: object, **_k: object) -> None:
+            msg = "API rate limit exceeded"
+            raise auto_update.UpdateCheckError(
+                auto_update.REASON_RATE_LIMITED, msg
+            )
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.check_for_update",
+            raise_rate,
+        )
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 3
+        assert "GITHUB_TOKEN" in result.stdout
+        assert "gh auth login" in result.stdout
 
 
 class TestUpdateCommandInstall:
@@ -131,7 +159,7 @@ class TestUpdateCommandInstall:
             update_available=True,
         )
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             lambda *_a, **_k: info,
         )
         install = MagicMock(return_value=0)
@@ -158,7 +186,7 @@ class TestUpdateCommandInstall:
             update_available=True,
         )
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             lambda *_a, **_k: info,
         )
         monkeypatch.setattr(
@@ -180,7 +208,7 @@ class TestUpdateCommandInstall:
             update_available=True,
         )
         monkeypatch.setattr(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             lambda *_a, **_k: info,
         )
 
@@ -208,7 +236,7 @@ class TestRootCallbackHooks:
         monkeypatch.setattr("discovery.poll.cli.atexit.register", register)
 
         with patch(
-            "discovery.poll.cli_update.fetch_update_info",
+            "discovery.poll.cli_update.check_for_update",
             return_value=None,
         ):
             runner.invoke(app, ["update", "--check"])

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
@@ -76,7 +76,7 @@ class TestUpdateCommandCheck:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.check_for_update",
-            lambda *_a, **_k: info,
+            lambda *_a, **_k: (info, None),
         )
         result = runner.invoke(app, ["update"])
         assert result.exit_code == 0
@@ -96,7 +96,7 @@ class TestUpdateCommandCheck:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.check_for_update",
-            lambda *_a, **_k: info,
+            lambda *_a, **_k: (info, None),
         )
         result = runner.invoke(app, ["update", "--check"])
         assert result.exit_code == 0
@@ -160,7 +160,7 @@ class TestUpdateCommandInstall:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.check_for_update",
-            lambda *_a, **_k: info,
+            lambda *_a, **_k: (info, None),
         )
         install = MagicMock(return_value=0)
         monkeypatch.setattr(
@@ -187,7 +187,7 @@ class TestUpdateCommandInstall:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.check_for_update",
-            lambda *_a, **_k: info,
+            lambda *_a, **_k: (info, None),
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.install_update",
@@ -209,7 +209,7 @@ class TestUpdateCommandInstall:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_update.check_for_update",
-            lambda *_a, **_k: info,
+            lambda *_a, **_k: (info, None),
         )
 
         def explode(*_a: object, **_k: object) -> int:

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_update.py
@@ -1,0 +1,238 @@
+"""Tests for the ``discovery update`` Typer command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from discovery.common import auto_update
+from discovery.common.auto_update import maybe_notify
+from discovery.poll.cli import app
+
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def fake_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(
+        "discovery.common.auto_update.get_home_dir",
+        lambda: tmp_path,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def installed_build(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(
+        "discovery._version.get_build_commit", lambda: "deadbeef"
+    )
+    monkeypatch.setattr(
+        "discovery.common.auto_update.get_build_commit", lambda: "deadbeef"
+    )
+    monkeypatch.setattr(
+        "discovery.poll.cli_update.get_build_commit", lambda: "deadbeef"
+    )
+    return "deadbeef"
+
+
+class TestUpdateCommandFlags:
+    def test_disable_persists_flag(
+        self, fake_home: Path, installed_build: str
+    ) -> None:
+        result = runner.invoke(app, ["update", "--disable"])
+        assert result.exit_code == 0
+        assert auto_update.load_cache().disabled is True
+
+    def test_enable_clears_flag(
+        self, fake_home: Path, installed_build: str
+    ) -> None:
+        auto_update.set_disabled(True)
+        result = runner.invoke(app, ["update", "--enable"])
+        assert result.exit_code == 0
+        assert auto_update.load_cache().disabled is False
+
+    def test_enable_and_disable_are_mutually_exclusive(
+        self, fake_home: Path, installed_build: str
+    ) -> None:
+        result = runner.invoke(app, ["update", "--enable", "--disable"])
+        assert result.exit_code == 2
+
+
+class TestUpdateCommandCheck:
+    def test_reports_up_to_date(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit=installed_build,
+            update_available=False,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 0
+        assert "latest version" in result.stdout
+
+    def test_reports_update_available_with_check_flag(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            latest_commit_date="2025-06-01T00:00:00Z",
+            update_available=True,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+        result = runner.invoke(app, ["update", "--check"])
+        assert result.exit_code == 0
+        assert "cafef00d" in result.stdout
+        assert "discovery update" in result.stdout
+
+    def test_network_failure_exits_3(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: None,
+        )
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 3
+        assert "Could not reach GitHub" in result.stdout
+
+
+class TestUpdateCommandInstall:
+    def test_install_with_yes_runs_uv(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            update_available=True,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+        install = MagicMock(return_value=0)
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.install_update", install
+        )
+        result = runner.invoke(app, ["update", "--yes"])
+        assert result.exit_code == 0
+        install.assert_called_once()
+        # The successful install should baseline the cache so the
+        # at-exit notifier doesn't immediately re-trigger.
+        state = auto_update.load_cache()
+        assert state.notified_commit == "cafef00d"
+
+    def test_install_failure_exits_with_subprocess_code(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            update_available=True,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.install_update",
+            lambda *_a, **_k: 7,
+        )
+        result = runner.invoke(app, ["update", "--yes"])
+        assert result.exit_code == 7
+
+    def test_install_missing_uv_exits_1(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_home: Path,
+        installed_build: str,
+    ) -> None:
+        info = auto_update.UpdateInfo(
+            current_commit=installed_build,
+            latest_commit="cafef00d",
+            update_available=True,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.fetch_update_info",
+            lambda *_a, **_k: info,
+        )
+
+        def explode(*_a: object, **_k: object) -> int:
+            msg = "uv not on PATH"
+            raise auto_update.UpgradeError(msg)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_update.install_update", explode
+        )
+        result = runner.invoke(app, ["update", "--yes"])
+        assert result.exit_code == 1
+        assert "uv not on PATH" in result.stdout
+
+
+class TestRootCallbackHooks:
+    """The root callback should arm the auto-update machinery."""
+
+    def test_schedule_and_atexit_register_on_invocation(
+        self, monkeypatch: pytest.MonkeyPatch, fake_home: Path
+    ) -> None:
+        schedule = MagicMock()
+        register = MagicMock()
+        monkeypatch.setattr("discovery.poll.cli.schedule_check", schedule)
+        monkeypatch.setattr("discovery.poll.cli.atexit.register", register)
+
+        with patch(
+            "discovery.poll.cli_update.fetch_update_info",
+            return_value=None,
+        ):
+            runner.invoke(app, ["update", "--check"])
+        assert schedule.called
+        assert register.called
+        # The registered callable must be maybe_notify.
+        assert any(
+            call.args and call.args[0] is maybe_notify
+            for call in register.call_args_list
+        )
+
+    def test_version_flag_also_arms_auto_update(
+        self, monkeypatch: pytest.MonkeyPatch, fake_home: Path
+    ) -> None:
+        """`--version` is an eager Typer callback that exits before the
+        main callback body runs; the auto-update wiring must still fire
+        so users running only `--version` are not stuck on a stale cache.
+        """
+        schedule = MagicMock()
+        register = MagicMock()
+        monkeypatch.setattr("discovery.poll.cli.schedule_check", schedule)
+        monkeypatch.setattr("discovery.poll.cli.atexit.register", register)
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "discovery" in result.stdout
+        assert schedule.called
+        assert register.called


### PR DESCRIPTION
## Summary

Adds a Copilot-CLI-style auto-update flow to the Discovery supercomputer CLI: every invocation does a daemon-thread background check (24h-throttled), and emits a single line at exit when a newer release is available. Users can run `discovery update` to apply it.

```
🔔 A new version of the Discovery CLI is available (2026-06-01)
   Current: 1633c830  ->  Latest: 749f5010
   Run uv tool upgrade discovery or discovery update to upgrade.
```

## Design

### Background check (`discovery.common.auto_update`)
- **Daemon thread, never blocks**: every CLI invocation reads a small `~/.discovery/update-check.json` cache. If it's stale (>24h) a daemon thread refreshes it asynchronously. Failures are swallowed silently.
- **Subdirectory-aware**: uses the GitHub *compare* API and only reports an update when at least one changed file lives under `utilities/supercomputer-cli/`. Avoids "your CLI is out of date" noise from unrelated monorepo activity (catalog edits, doc tweaks, other utilities).
- **Idempotent notification**: the at-exit notification fires once per upstream commit — re-shows only when a *newer* commit appears.
- **Authentication optional**: the public-repo path works fully unauthenticated. The checker opportunistically uses `DISCOVERY_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token` to raise the rate limit from 60/hr to 5000/hr — no setup required for most developers.

### `discovery update` command
- `discovery update` — interactive check + confirm + install
- `discovery update --check` — check only (exit 0 = up to date, 3 = network/auth failure)
- `discovery update -y` — install without confirmation
- `discovery update --enable` / `--disable` — toggle persistent background checks

Installs are applied via `uv tool upgrade discovery`. On any failure the CLI prints a categorized hint (rate-limited → suggests `GITHUB_TOKEN` or `gh auth login`; 404 → points at `DISCOVERY_UPDATE_REPO`/`REF`; network → suggests checking proxy/DNS).

### Environment toggles
| Env var | Effect |
| --- | --- |
| `DISCOVERY_NO_UPDATE_CHECK=1` | Skip checks for this invocation (CI-friendly) |
| `DISCOVERY_GITHUB_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN` | Raise GitHub API rate limit |
| `DISCOVERY_UPDATE_REF=<ref>` | Follow a non-default branch / tag / SHA |
| `DISCOVERY_UPDATE_REPO=<owner/name>` | Follow a fork (RC channel, end-to-end testing) |

### Other surfaces
- `discovery doctor` gained a section reporting cache state and any pending update.
- The conftest installs an autouse fixture that disables network update checks so test runs never accidentally hit `api.github.com`.

## End-to-end verification

Done against my fork (`matt-chan/discovery`) using `DISCOVERY_UPDATE_REPO`/`REF` to simulate "real" upstream activity without merging an extra commit to `main`. Flow:

1. `uv tool install discovery --from "git+https://github.com/matt-chan/discovery.git@feat/cli-auto-update#subdirectory=utilities/supercomputer-cli/discovery"` → installed at `1633c830`
2. Pushed a new commit (`749f5010`) on the same branch
3. `discovery update --check` correctly reported the new commit:
   ```
   Update available: 749f5010 (2026-06-01)
   Installed:      1633c830
   ```
4. `discovery update -y` ran `uv tool upgrade discovery`, refetched the branch, installed the new SHA
5. `discovery --version` then reported `0.1.0+g749f5010`
6. Re-running `discovery update --check` reported "You are on the latest version" (idempotency guard verified)

The no-token path was separately verified anonymously against `octocat/Hello-World` (200 OK, no `Authorization` header).

## Test coverage

71 new test cases in `tests/test_auto_update.py` and `tests/test_cli_update.py`, covering:

- Cache I/O round-trip + corrupt/unknown-key tolerance
- Opt-out (env var + persistent flag) + cache staleness math
- Token resolution priority chain (env vars → `gh auth token` → none)
- All 7 error categories (`rate_limited`, `unauthorized`, `not_found`, `network`, `http_error`, `parse_error`, `ineligible`)
- Subdir filtering: ignores changes outside the CLI subdir; picks the newest CLI-touching commit when others are interleaved
- Notification idempotency (re-fires on new commits, suppresses repeats)
- `uv` missing → typed `UpgradeError`
- Root-callback wiring + `--version` eager-callback wiring (regression test for an early bug where `--version` exited before the auto-update was armed)

Full suite: **427 passed** (excluding 10 pre-existing failures from a missing `tests/artifacts/response.json` fixture, unrelated to this change). `ruff check` and `mypy --exclude .venv` clean on all changed files.

## Out of scope / future work

- Atomic rollback (`discovery update --rollback`) — could re-pin to the prior commit recorded in `current_at_check`.
- Channels (stable / rc / beta) — `DISCOVERY_UPDATE_REF` is the building block; a `~/.discovery-sc-config` setting could persist the choice.
- Release notes display — the compare-API response already contains commit messages; surfacing a one-line summary in the at-exit notice would be a small follow-up.
