### PR TITLE
feat(cli): local job-submit history and `--mine` filter

### DIFF
--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -193,6 +193,7 @@ Manage and monitor Discovery jobs:
 | `discovery job batch <command>` | Submit multiple independent tool runs (no polling) |
 | `discovery job vscode [--tunnel-name <name>]` | Start a job that hosts a VS Code tunnel (default name: `discovery-<username>`) |
 | `discovery job cancel <operation-id>` | Cancel a running operation |
+| `discovery job cancel --since 10m` | Bulk-cancel every locally-recorded job submitted in the last 10 minutes |
 | `discovery job running` | List your running operations (this machine); `--all` to see everyone's |
 | `discovery job pending` | List your queued operations (this machine); `--all` to see everyone's |
 | `discovery job done` | List your completed operations (this machine); `--all` to see everyone's |
@@ -247,6 +248,11 @@ discovery job list --all            # everyone's
 discovery job list --user alice     # alice's (implies --all)
 discovery job running                # mine, running now
 discovery job running --all          # everyone's running
+
+# Bulk-cancel everything you submitted from this machine in the last 10
+# minutes (current workspace only; --yes skips the interactive confirm).
+discovery job cancel --since 10m
+discovery job cancel --since 1h --yes
 
 # Submit several independent runs in one shot
 discovery job batch 4 "python -c 'print(\"hello\")'"

--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -193,10 +193,10 @@ Manage and monitor Discovery jobs:
 | `discovery job batch <command>` | Submit multiple independent tool runs (no polling) |
 | `discovery job vscode [--tunnel-name <name>]` | Start a job that hosts a VS Code tunnel (default name: `discovery-<username>`) |
 | `discovery job cancel <operation-id>` | Cancel a running operation |
-| `discovery job running` | List running operations (filtered to current user) |
-| `discovery job pending` | List queued operations (filtered to current user) |
-| `discovery job done` | List completed operations (succeeded/failed/canceled) |
-| `discovery job list` | List recent operations with filters |
+| `discovery job running` | List your running operations (this machine); `--all` to see everyone's |
+| `discovery job pending` | List your queued operations (this machine); `--all` to see everyone's |
+| `discovery job done` | List your completed operations (this machine); `--all` to see everyone's |
+| `discovery job list` | List your recent operations (this machine); `--all` or `--user X` to widen |
 | `discovery job status [operation-id]` | Get compute usage, or status of a specific operation |
 | `discovery job pools` | List available nodepools from configuration |
 | `discovery job cleanup-anf` | List stale operations whose ANF scratch folders can be cleaned up |
@@ -205,9 +205,10 @@ Manage and monitor Discovery jobs:
 > **Local job history.** Every `discovery job start` / `batch` / `vscode`
 > records the operation ID + command + tool + nodepool + project + workspace
 > to `~/.discovery/job-history.jsonl` (one JSON-Lines record per submit).
-> Use `discovery job history` to browse it, or pass `--mine` to
-> `discovery job list / running / pending / done` to restrict the
-> server-side listing to jobs you submitted from this machine. Set
+> `discovery job list / running / pending / done` filter to this machine's
+> history by default — pass `--all` (or `--user X` on `list`) to widen the
+> view to other people / other machines. Use `discovery job history` to
+> browse the local store directly without hitting the service. Set
 > `DISCOVERY_NO_JOB_HISTORY=1` to disable recording for an invocation.
 
 **Examples:**
@@ -239,10 +240,13 @@ discovery job history --limit 10
 discovery job history --since 7d
 discovery job history --all-workspaces --this-host
 
-# Filter server-side listings to your local submissions
-discovery job list --mine
-discovery job running --mine
-discovery job done --mine
+# Server-side listings default to jobs from this machine — pass --all
+# to widen the view (or --user X on `list` for a specific submitter)
+discovery job list                  # mine
+discovery job list --all            # everyone's
+discovery job list --user alice     # alice's (implies --all)
+discovery job running                # mine, running now
+discovery job running --all          # everyone's running
 
 # Submit several independent runs in one shot
 discovery job batch 4 "python -c 'print(\"hello\")'"

--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -200,6 +200,15 @@ Manage and monitor Discovery jobs:
 | `discovery job status [operation-id]` | Get compute usage, or status of a specific operation |
 | `discovery job pools` | List available nodepools from configuration |
 | `discovery job cleanup-anf` | List stale operations whose ANF scratch folders can be cleaned up |
+| `discovery job history` | List, locate, or wipe the local job-submit history |
+
+> **Local job history.** Every `discovery job start` / `batch` / `vscode`
+> records the operation ID + command + tool + nodepool + project + workspace
+> to `~/.discovery/job-history.jsonl` (one JSON-Lines record per submit).
+> Use `discovery job history` to browse it, or pass `--mine` to
+> `discovery job list / running / pending / done` to restrict the
+> server-side listing to jobs you submitted from this machine. Set
+> `DISCOVERY_NO_JOB_HISTORY=1` to disable recording for an invocation.
 
 **Examples:**
 
@@ -223,6 +232,17 @@ discovery job start --scratch "python train.py --workdir /scratch/run"
 # default). The Scratch lookup auto-routes to whichever SC the chosen
 # pool lives on.
 discovery job start --pool ibtest2/hbv4 --scratch "echo hi"
+
+# Browse jobs you've submitted from this machine (offline, no API call)
+discovery job history
+discovery job history --limit 10
+discovery job history --since 7d
+discovery job history --all-workspaces --this-host
+
+# Filter server-side listings to your local submissions
+discovery job list --mine
+discovery job running --mine
+discovery job done --mine
 
 # Submit several independent runs in one shot
 discovery job batch 4 "python -c 'print(\"hello\")'"

--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -241,6 +241,10 @@ discovery job history --limit 10
 discovery job history --since 7d
 discovery job history --all-workspaces --this-host
 
+# Add live status + computed runtime (one parallel API call per entry)
+discovery job history --status
+discovery job history --status --since 24h
+
 # Server-side listings default to jobs from this machine — pass --all
 # to widen the view (or --user X on `list` for a specific submitter)
 discovery job list                  # mine

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
@@ -38,7 +38,7 @@ import socket
 import threading
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field, fields
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -364,6 +364,48 @@ def _parse_iso(value: str) -> datetime | None:
         return None
 
 
+# Supported time-unit suffixes for :func:`parse_since`. Order matters
+# only for documentation — the parser looks up by character.
+_SINCE_UNITS: dict[str, timedelta] = {
+    "s": timedelta(seconds=1),
+    "m": timedelta(minutes=1),
+    "h": timedelta(hours=1),
+    "d": timedelta(days=1),
+    "w": timedelta(weeks=1),
+}
+
+
+def parse_since(value: str) -> datetime:
+    """Parse a ``--since`` value into a UTC ``datetime`` cutoff.
+
+    Accepts:
+      * Absolute date: ``YYYY-MM-DD`` (UTC midnight).
+      * Relative shorthand: ``<N><unit>`` where unit is one of
+        ``s``/``m``/``h``/``d``/``w`` (seconds / minutes / hours /
+        days / weeks). Examples: ``30s``, ``10m``, ``24h``, ``7d``,
+        ``2w``.
+
+    Raises:
+        ValueError: If ``value`` does not match either format.
+    """
+    text = (value or "").strip()
+    if not text:
+        msg = "empty --since value"
+        raise ValueError(msg)
+    now = datetime.now(tz=timezone.utc)
+    if len(text) >= 2 and text[:-1].isdigit() and text[-1] in _SINCE_UNITS:
+        n = int(text[:-1])
+        return now - n * _SINCE_UNITS[text[-1]]
+    try:
+        return datetime.strptime(text, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        msg = (
+            f"Invalid --since value: {value!r}. Expected YYYY-MM-DD or a "
+            "duration like '30s', '10m', '24h', '7d', '2w'."
+        )
+        raise ValueError(msg) from exc
+
+
 # ---------------------------------------------------------------------------
 # Maintenance
 # ---------------------------------------------------------------------------
@@ -453,6 +495,7 @@ __all__ = [
     "is_disabled",
     "load_history",
     "local_operation_ids",
+    "parse_since",
     "prune",
     "record_submission",
 ]

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
@@ -120,6 +120,15 @@ class JobHistoryEntry:
     workspace_url: str = ""
     mode: str = MODE_START
     cli_argv: list[str] = field(default_factory=list)
+    # Azure principal that was logged in (``az account show --query
+    # user.name``) at submit time. Used by ``discovery job cancel
+    # --since`` to avoid cancelling jobs that were submitted from this
+    # machine but under a *different* Azure login (e.g., a shared
+    # workstation, a build agent that re-authenticates between users).
+    # Empty for entries written before this field was added — those
+    # are treated as "matches any user" so backwards compatibility is
+    # preserved.
+    azure_username: str = ""
     schema_version: int = SCHEMA_VERSION
 
     @classmethod
@@ -194,6 +203,7 @@ def record_submission(
     cli_argv: list[str] | None = None,
     hostname: str | None = None,
     submitted_at: str | None = None,
+    azure_username: str = "",
 ) -> JobHistoryEntry | None:
     """Append an entry to the local job-history file.
 
@@ -219,6 +229,7 @@ def record_submission(
         workspace_url=workspace_url,
         mode=mode,
         cli_argv=list(cli_argv) if cli_argv is not None else [],
+        azure_username=azure_username,
     )
 
     line = json.dumps(asdict(entry), separators=(",", ":")) + "\n"

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
@@ -101,8 +101,8 @@ class JobHistoryEntry:
         nodepool_id: Effective nodepool ID (after ``--pool`` resolution).
         project_name: ``env_cfg.project_name`` at submit time.
         workspace_url: ``env_cfg.workspace_url`` at submit time. Used to
-            avoid showing entries from a different Discovery
-            environment when the user later runs ``--mine``.
+            scope queries by workspace so the user doesn't see entries
+            from a different Discovery environment.
         mode: One of :data:`MODE_START`, :data:`MODE_BATCH`,
             :data:`MODE_VSCODE`.
         cli_argv: The full ``sys.argv`` at submit time. Useful for

--- a/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/common/job_history.py
@@ -1,0 +1,458 @@
+"""Local history of jobs submitted from this machine.
+
+Each ``discovery job start`` / ``discovery job batch`` / ``discovery job
+vscode`` call appends a single JSON-Lines record to
+``~/.discovery/job-history.jsonl`` so that future invocations can
+filter ``discovery job list``-style queries to just *your* submissions
+— even when the service still returns jobs from teammates or from
+other machines you own.
+
+Why JSON-Lines
+--------------
+* Append-only, lock-friendly: each line is a complete record that can
+  be written atomically with a single ``write()`` (well under the
+  POSIX-guaranteed ``PIPE_BUF`` of 512 bytes for tiny records, and we
+  serialize bigger ones under an in-process lock for portability).
+* Easy to read with ``cat``, ``jq``, ``head -n``, etc.
+* No native-dep / DB requirement (this CLI runs in heterogeneous
+  environments — Linux laptops, WSL, AKS pods).
+* Forward-compatible: unknown keys are ignored by the loader, so we
+  can add fields without breaking older releases that read the file.
+
+Privacy
+-------
+Everything written stays on disk. Records include the command string
+the user typed and the local hostname so multi-machine users can tell
+where a job originated. Disable the recording entirely with
+``DISCOVERY_NO_JOB_HISTORY=1`` (one-shot) or call :func:`clear` to
+wipe the file. The recorder *never* fails the submit on I/O error —
+recording is opportunistic.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import socket
+import threading
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from discovery.common.logging import debug
+from discovery.common.paths import get_home_dir
+
+
+HISTORY_DIR_NAME = ".discovery"
+HISTORY_FILE_NAME = "job-history.jsonl"
+SCHEMA_VERSION = 1
+
+# Truthy values that disable history recording when set on
+# ``DISCOVERY_NO_JOB_HISTORY``.
+ENV_OPT_OUT = "DISCOVERY_NO_JOB_HISTORY"
+ENV_OPT_OUT_TRUTHY = {"1", "true", "True", "TRUE", "yes", "YES", "on", "ON"}
+
+# Submit-mode tags written into each record so downstream readers can
+# tell the start / batch / vscode commands apart without re-parsing
+# argv.
+MODE_START = "start"
+MODE_BATCH = "batch"
+MODE_VSCODE = "vscode"
+
+# In-process lock that serializes appends from a single Python process.
+# ``discovery job batch`` submits via a :class:`ThreadPoolExecutor`, so
+# multiple worker threads will land in :func:`record_submission`
+# concurrently; without the lock interleaved writes could corrupt the
+# JSONL file. We intentionally do *not* take a cross-process file lock
+# (no POSIX-portable, dependency-free way to do that reliably) — two
+# different ``discovery`` processes writing simultaneously could in
+# theory interleave large records, but in practice each line is well
+# under the kernel's atomic-write threshold for ``O_APPEND`` writes on
+# Linux/macOS/WSL.
+_WRITE_LOCK = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Record model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JobHistoryEntry:
+    """A single ``discovery job <submit>`` invocation record.
+
+    All fields are optional except ``operation_id`` and ``submitted_at``
+    so older / newer records can still be deserialized when the schema
+    grows.
+
+    Attributes:
+        operation_id: Service-side operation UUID returned by
+            ``start_tool_run``.
+        submitted_at: UTC ISO-8601 timestamp of the local submit call.
+        hostname: ``socket.gethostname()`` at submit time. Helps users
+            with several machines pointing at the same Discovery
+            workspace tell submissions apart.
+        command: The user's bash command (the first positional arg to
+            ``discovery job start`` / ``batch``).
+        tool_id: ``env_cfg.tool_id`` at submit time.
+        nodepool_id: Effective nodepool ID (after ``--pool`` resolution).
+        project_name: ``env_cfg.project_name`` at submit time.
+        workspace_url: ``env_cfg.workspace_url`` at submit time. Used to
+            avoid showing entries from a different Discovery
+            environment when the user later runs ``--mine``.
+        mode: One of :data:`MODE_START`, :data:`MODE_BATCH`,
+            :data:`MODE_VSCODE`.
+        cli_argv: The full ``sys.argv`` at submit time. Useful for
+            re-running a job verbatim.
+        schema_version: :data:`SCHEMA_VERSION` at write time.
+    """
+
+    operation_id: str
+    submitted_at: str
+    hostname: str = ""
+    command: str = ""
+    tool_id: str = ""
+    nodepool_id: str = ""
+    project_name: str = ""
+    workspace_url: str = ""
+    mode: str = MODE_START
+    cli_argv: list[str] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> JobHistoryEntry | None:
+        """Construct an entry from a JSON-decoded mapping, ignoring unknown keys.
+
+        Returns ``None`` when required fields are missing or malformed
+        so callers can simply skip bad lines.
+        """
+        op_id = data.get("operation_id")
+        ts = data.get("submitted_at")
+        if not isinstance(op_id, str) or not op_id:
+            return None
+        if not isinstance(ts, str) or not ts:
+            return None
+        kwargs: dict[str, Any] = {}
+        valid = {f.name for f in fields(cls)}
+        for key, value in data.items():
+            if key in valid:
+                kwargs[key] = value
+        try:
+            return cls(**kwargs)
+        except (TypeError, ValueError) as exc:
+            debug(f"job-history: skipping malformed entry {op_id}: {exc}")
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+def history_path() -> Path:
+    """Return the absolute path to ``~/.discovery/job-history.jsonl``."""
+    return get_home_dir() / HISTORY_DIR_NAME / HISTORY_FILE_NAME
+
+
+def _env_opt_out() -> bool:
+    """``True`` when the user has set ``DISCOVERY_NO_JOB_HISTORY``."""
+    return os.environ.get(ENV_OPT_OUT, "") in ENV_OPT_OUT_TRUTHY
+
+
+def is_disabled() -> bool:
+    """Return ``True`` when history recording is disabled for this process."""
+    return _env_opt_out()
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp with a trailing ``Z`` (RFC 3339-style)."""
+    return (
+        datetime.now(tz=timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+def record_submission(
+    operation_id: str,
+    *,
+    command: str = "",
+    tool_id: str = "",
+    nodepool_id: str = "",
+    project_name: str = "",
+    workspace_url: str = "",
+    mode: str = MODE_START,
+    cli_argv: list[str] | None = None,
+    hostname: str | None = None,
+    submitted_at: str | None = None,
+) -> JobHistoryEntry | None:
+    """Append an entry to the local job-history file.
+
+    Returns the entry on success, or ``None`` when recording was
+    skipped (opted-out or the operation_id was empty). I/O errors are
+    logged at DEBUG and swallowed — recording must never break the
+    user's submit.
+    """
+    if is_disabled():
+        debug(f"job-history: opt-out active, not recording {operation_id}")
+        return None
+    if not operation_id:
+        return None
+
+    entry = JobHistoryEntry(
+        operation_id=operation_id,
+        submitted_at=submitted_at or _utc_now_iso(),
+        hostname=hostname if hostname is not None else _safe_hostname(),
+        command=command,
+        tool_id=tool_id,
+        nodepool_id=nodepool_id,
+        project_name=project_name,
+        workspace_url=workspace_url,
+        mode=mode,
+        cli_argv=list(cli_argv) if cli_argv is not None else [],
+    )
+
+    line = json.dumps(asdict(entry), separators=(",", ":")) + "\n"
+    path = history_path()
+    try:
+        with _WRITE_LOCK:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+    except OSError as exc:
+        debug(f"job-history: failed to append {operation_id}: {exc}")
+        return None
+    return entry
+
+
+def _safe_hostname() -> str:
+    """Return :func:`socket.gethostname` with an empty-string fallback."""
+    try:
+        return socket.gethostname() or ""
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+def load_history(
+    *,
+    workspace_url: str | None = None,
+    project_name: str | None = None,
+    hostname: str | None = None,
+    since: datetime | None = None,
+) -> list[JobHistoryEntry]:
+    """Load all history entries, optionally narrowed by metadata.
+
+    Args:
+        workspace_url: When provided, only return entries that match
+            this workspace exactly (so a user pointing at a different
+            Discovery environment doesn't see unrelated jobs).
+        project_name: When provided, narrow further by project name.
+        hostname: When provided, narrow to entries written on this
+            host. Useful for users who roam between machines.
+        since: When provided, only return entries with
+            ``submitted_at >= since``. Naive datetimes are interpreted
+            as UTC.
+
+    Returns:
+        Entries in *write order* (oldest first). Malformed / unreadable
+        records are skipped silently.
+    """
+    path = history_path()
+    if not path.is_file():
+        return []
+
+    if since is not None and since.tzinfo is None:
+        since = since.replace(tzinfo=timezone.utc)
+
+    out: list[JobHistoryEntry] = []
+    try:
+        with path.open(encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                entry = JobHistoryEntry.from_mapping(data)
+                if entry is None:
+                    continue
+                if not _entry_matches(
+                    entry,
+                    workspace_url=workspace_url,
+                    project_name=project_name,
+                    hostname=hostname,
+                    since=since,
+                ):
+                    continue
+                out.append(entry)
+    except OSError as exc:
+        debug(f"job-history: failed to read {path}: {exc}")
+        return []
+    return out
+
+
+def _entry_matches(
+    entry: JobHistoryEntry,
+    *,
+    workspace_url: str | None,
+    project_name: str | None,
+    hostname: str | None,
+    since: datetime | None,
+) -> bool:
+    """Apply the optional filter predicates from :func:`load_history`."""
+    if workspace_url is not None and entry.workspace_url != workspace_url:
+        return False
+    if project_name is not None and entry.project_name != project_name:
+        return False
+    if hostname is not None and entry.hostname != hostname:
+        return False
+    if since is not None:
+        ts = _parse_iso(entry.submitted_at)
+        if ts is None or ts < since:
+            return False
+    return True
+
+
+def local_operation_ids(
+    *,
+    workspace_url: str | None = None,
+    project_name: str | None = None,
+    hostname: str | None = None,
+    since: datetime | None = None,
+) -> set[str]:
+    """Return the set of operation IDs in the local history.
+
+    Convenience wrapper for use as a ``filter_fn`` predicate in the
+    ``discovery job list`` family of commands.
+    """
+    return {
+        entry.operation_id
+        for entry in load_history(
+            workspace_url=workspace_url,
+            project_name=project_name,
+            hostname=hostname,
+            since=since,
+        )
+    }
+
+
+def _parse_iso(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp; return ``None`` on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Maintenance
+# ---------------------------------------------------------------------------
+
+
+def clear() -> int:
+    """Delete the entire history file. Returns the number of entries removed."""
+    path = history_path()
+    if not path.is_file():
+        return 0
+    count = sum(1 for _ in path.read_text(encoding="utf-8").splitlines() if _.strip())
+    try:
+        path.unlink()
+    except OSError as exc:
+        debug(f"job-history: failed to delete {path}: {exc}")
+        return 0
+    return count
+
+
+def prune(
+    *, keep_count: int | None = None, keep_since: datetime | None = None
+) -> int:
+    """Rewrite the history file keeping only the most recent entries.
+
+    Args:
+        keep_count: Keep at most this many entries (newest first).
+        keep_since: Keep entries with ``submitted_at >= keep_since``.
+
+    Returns:
+        Number of entries removed.
+    """
+    entries = load_history()
+    if not entries:
+        return 0
+
+    keep: list[JobHistoryEntry] = list(entries)
+
+    if keep_since is not None:
+        if keep_since.tzinfo is None:
+            keep_since = keep_since.replace(tzinfo=timezone.utc)
+        keep = [
+            e for e in keep
+            if (ts := _parse_iso(e.submitted_at)) is not None and ts >= keep_since
+        ]
+
+    if keep_count is not None and len(keep) > keep_count:
+        keep = keep[-keep_count:]
+
+    removed = len(entries) - len(keep)
+    if removed <= 0:
+        return 0
+
+    _rewrite(keep)
+    return removed
+
+
+def _rewrite(entries: Iterable[JobHistoryEntry]) -> None:
+    """Atomically replace the history file with ``entries`` (write order)."""
+    path = history_path()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        with _WRITE_LOCK:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with tmp.open("w", encoding="utf-8") as fh:
+                for entry in entries:
+                    fh.write(
+                        json.dumps(asdict(entry), separators=(",", ":")) + "\n"
+                    )
+            tmp.replace(path)
+    except OSError as exc:
+        debug(f"job-history: rewrite failed: {exc}")
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+
+
+__all__ = [
+    "ENV_OPT_OUT",
+    "HISTORY_DIR_NAME",
+    "HISTORY_FILE_NAME",
+    "MODE_BATCH",
+    "MODE_START",
+    "MODE_VSCODE",
+    "SCHEMA_VERSION",
+    "JobHistoryEntry",
+    "clear",
+    "history_path",
+    "is_disabled",
+    "load_history",
+    "local_operation_ids",
+    "prune",
+    "record_submission",
+]

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli.py
@@ -41,6 +41,7 @@ from .cli_doctor import app as doctor_app
 from .cli_helpers import (  # noqa: F401
     emit_env as _emit_env,
 )
+from .cli_history import app as history_app
 from .cli_smoke import app as smoke_test_app
 from .cli_status import app as status_app
 from .cli_storage import app as storage_app
@@ -135,6 +136,7 @@ job_app.command(name="list")(status_app.registered_commands[3].callback)
 job_app.command(name="status")(status_app.registered_commands[4].callback)
 job_app.command(name="pools")(status_app.registered_commands[5].callback)
 job_app.command(name="cleanup-anf")(cleanup_app.registered_commands[0].callback)
+job_app.command(name="history")(history_app.registered_commands[0].callback)
 
 # 'build' group - build commands
 build_group_app.command(name="image")(build_app.registered_commands[0].callback)

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_doctor.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_doctor.py
@@ -24,6 +24,7 @@ from rich.console import Console
 from rich.table import Table
 
 from discovery._version import get_build_commit, get_version_string
+from discovery.common.job_history import history_path, is_disabled, load_history
 from discovery.common.paths import get_config_file_path
 from discovery.poll.az_extensions import check_required_extensions
 
@@ -37,6 +38,7 @@ _EXPECTED_MODULES = [
     "discovery",
     "discovery.common",
     "discovery.common.config",
+    "discovery.common.job_history",
     "discovery.common.logging",
     "discovery.poll",
     "discovery.poll.api",
@@ -49,6 +51,7 @@ _EXPECTED_MODULES = [
     "discovery.poll.cli_configure",
     "discovery.poll.cli_doctor",
     "discovery.poll.cli_helpers",
+    "discovery.poll.cli_history",
     "discovery.poll.cli_smoke",
     "discovery.poll.cli_status",
     "discovery.poll.cli_storage",
@@ -218,6 +221,27 @@ def _render_az_extensions_section() -> bool:
     return True
 
 
+def _render_job_history_section() -> None:
+    """Surface the local job-history state (informational, never fails)."""
+    path = history_path()
+    if is_disabled():
+        console.print(
+            "  [yellow]![/yellow] Job history: [yellow]disabled[/yellow] "
+            "(DISCOVERY_NO_JOB_HISTORY is set)"
+        )
+        return
+    if not path.is_file():
+        console.print(
+            f"  Job history: [dim]empty[/dim] ({path} will be created on first submit)"
+        )
+        return
+    entries = load_history()
+    console.print(
+        f"  [green]✓[/green] Job history: {len(entries)} entr"
+        f"{'y' if len(entries) == 1 else 'ies'} at {path}"
+    )
+
+
 @app.command(name="doctor")
 def doctor_command() -> None:
     """Check installation health and report diagnostics."""
@@ -280,6 +304,9 @@ def doctor_command() -> None:
     # surfaces the situation early with an actionable hint.
     if not _render_az_extensions_section():
         all_ok = False
+
+    # Local job-history status — informational only.
+    _render_job_history_section()
 
     console.print()
     if all_ok:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
@@ -1,0 +1,214 @@
+"""``discovery job history`` — view and manage the local submit history.
+
+This is a *local* command: it reads ``~/.discovery/job-history.jsonl``
+and does not touch the Discovery service. Use it to remember what you
+submitted earlier (even across days), to find an operation ID after
+the service-side list has rolled over, or to wipe the history.
+"""
+
+from __future__ import annotations
+
+import socket
+from datetime import datetime, timedelta, timezone
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from discovery.common.job_history import (
+    JobHistoryEntry,
+    clear,
+    history_path,
+    load_history,
+)
+from discovery.common.logging import info
+from discovery.poll.cli_helpers import get_config_file_path, load_project_config
+
+
+app = typer.Typer(help="View and manage the local job-submit history")
+console = Console()
+
+EXIT_OK = 0
+EXIT_BAD_USAGE = 2
+
+MODE_STYLES = {
+    "start": "cyan",
+    "batch": "magenta",
+    "vscode": "green",
+}
+
+
+def _parse_since(value: str) -> datetime:
+    """Parse ``--since`` value: either ``YYYY-MM-DD`` or ``<N><unit>`` shorthand.
+
+    Supported shorthand units: ``h`` (hours), ``d`` (days), ``w`` (weeks).
+    Examples: ``24h``, ``7d``, ``2w``.
+    """
+    value = value.strip()
+    now = datetime.now(tz=timezone.utc)
+    if len(value) >= 2 and value[:-1].isdigit() and value[-1] in {"h", "d", "w"}:
+        n = int(value[:-1])
+        unit = value[-1]
+        if unit == "h":
+            return now - timedelta(hours=n)
+        if unit == "d":
+            return now - timedelta(days=n)
+        return now - timedelta(weeks=n)
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        msg = f"Invalid --since value: {value!r}. Expected YYYY-MM-DD, '24h', '7d', or '2w'."
+        raise typer.BadParameter(msg) from exc
+
+
+def _truncate(value: str, *, width: int) -> str:
+    """Truncate ``value`` to ``width`` chars with a trailing ellipsis."""
+    if len(value) <= width:
+        return value
+    if width <= 1:
+        return value[:width]
+    return value[: width - 1] + "…"
+
+
+def _format_relative(ts: datetime) -> str:
+    """Format ``ts`` as ``5m ago`` / ``2h ago`` / ``YYYY-MM-DD HH:MM``."""
+    now = datetime.now(tz=timezone.utc)
+    delta = now - ts
+    if delta < timedelta(seconds=0):
+        return ts.isoformat()
+    if delta < timedelta(minutes=1):
+        return f"{int(delta.total_seconds())}s ago"
+    if delta < timedelta(hours=1):
+        return f"{int(delta.total_seconds() // 60)}m ago"
+    if delta < timedelta(days=1):
+        return f"{int(delta.total_seconds() // 3600)}h ago"
+    if delta < timedelta(days=14):
+        return f"{int(delta.total_seconds() // 86400)}d ago"
+    return ts.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _render_table(entries: list[JobHistoryEntry]) -> None:
+    """Render entries as a Rich table (newest first)."""
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        expand=True,
+        show_lines=False,
+    )
+    table.add_column("Operation ID", style="white", no_wrap=True)
+    table.add_column("Submitted", no_wrap=True, width=18)
+    table.add_column("Mode", no_wrap=True, width=7)
+    table.add_column("Project", no_wrap=True, max_width=24, overflow="ellipsis")
+    table.add_column("Host", no_wrap=True, max_width=18, overflow="ellipsis")
+    table.add_column("Command", overflow="ellipsis")
+
+    for entry in entries:
+        try:
+            ts = datetime.fromisoformat(entry.submitted_at.replace("Z", "+00:00"))
+            ts_str = _format_relative(ts)
+        except ValueError:
+            ts_str = entry.submitted_at
+        mode_style = MODE_STYLES.get(entry.mode, "white")
+        table.add_row(
+            entry.operation_id,
+            ts_str,
+            f"[{mode_style}]{entry.mode}[/{mode_style}]",
+            entry.project_name or "—",
+            entry.hostname or "—",
+            _truncate(entry.command or "—", width=80),
+        )
+    console.print(table)
+
+
+@app.command(name="history")
+def history_command(
+    limit: int = typer.Option(
+        50, "--limit", "-n", help="Show the most recent N entries (default: 50)."
+    ),
+    since: str = typer.Option(
+        "",
+        "--since",
+        help=(
+            "Only show entries from on/after this point. Accepts YYYY-MM-DD or "
+            "shorthand like '24h', '7d', '2w'."
+        ),
+    ),
+    workspace: bool = typer.Option(
+        True,
+        "--workspace/--all-workspaces",
+        help=(
+            "Restrict to entries that match the current workspace_url (default). "
+            "Pass --all-workspaces to see every recorded submission."
+        ),
+    ),
+    this_host_only: bool = typer.Option(
+        False,
+        "--this-host",
+        help="Only show entries recorded on this machine.",
+    ),
+    show_path: bool = typer.Option(
+        False, "--path", help="Print the history file path and exit."
+    ),
+    clear_all: bool = typer.Option(
+        False, "--clear", help="Delete the entire history file and exit."
+    ),
+) -> None:
+    """List, locate, or wipe the local job-submit history."""
+    if show_path:
+        console.print(str(history_path()))
+        raise typer.Exit(code=EXIT_OK)
+
+    if clear_all:
+        if not typer.confirm(
+            f"Delete {history_path()} and forget all locally-recorded jobs?",
+            default=False,
+        ):
+            raise typer.Exit(code=EXIT_OK)
+        removed = clear()
+        info(f"Removed {removed} history entr{'y' if removed == 1 else 'ies'}.")
+        raise typer.Exit(code=EXIT_OK)
+
+    workspace_url: str | None = None
+    if workspace:
+        try:
+            env_cfg = load_project_config(get_config_file_path())
+            workspace_url = env_cfg.workspace_url or None
+        except Exception:
+            workspace_url = None
+
+    since_dt = _parse_since(since) if since else None
+
+    hostname_filter: str | None = None
+    if this_host_only:
+        try:
+            hostname_filter = socket.gethostname()
+        except OSError:
+            hostname_filter = None
+
+    entries = load_history(
+        workspace_url=workspace_url,
+        hostname=hostname_filter,
+        since=since_dt,
+    )
+
+    if not entries:
+        path = history_path()
+        info(
+            f"No local job-history entries found at {path}. "
+            "Submit a job with `discovery job start` first."
+        )
+        raise typer.Exit(code=EXIT_OK)
+
+    # Newest first, then truncated by --limit
+    entries_sorted = sorted(entries, key=lambda e: e.submitted_at, reverse=True)
+    if limit > 0:
+        entries_sorted = entries_sorted[:limit]
+
+    _render_table(entries_sorted)
+    console.print(
+        f"\n[dim]{len(entries_sorted)} of {len(entries)} matching entries · "
+        f"file: {history_path()}[/dim]"
+    )
+
+
+__all__ = ["app", "history_command"]

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
@@ -1,16 +1,23 @@
 """``discovery job history`` — view and manage the local submit history.
 
-This is a *local* command: it reads ``~/.discovery/job-history.jsonl``
-and does not touch the Discovery service. Use it to remember what you
-submitted earlier (even across days), to find an operation ID after
-the service-side list has rolled over, or to wipe the history.
+This is primarily a *local* command: it reads
+``~/.discovery/job-history.jsonl`` and does not touch the Discovery
+service. Use it to remember what you submitted earlier (even across
+days), to find an operation ID after the service-side list has rolled
+over, or to wipe the history.
+
+Pass ``--status`` to additionally fetch each entry's current status
+and computed runtime from the API in parallel.
 """
 
 from __future__ import annotations
 
 import socket
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
+import httpx
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -22,8 +29,9 @@ from discovery.common.job_history import (
     load_history,
     parse_since,
 )
-from discovery.common.logging import info
+from discovery.common.logging import debug, info
 from discovery.poll.cli_helpers import get_config_file_path, load_project_config
+from discovery.poll.dataplane_api import get_operation_status
 
 
 app = typer.Typer(help="View and manage the local job-submit history")
@@ -73,8 +81,136 @@ def _format_relative(ts: datetime) -> str:
     return ts.astimezone().strftime("%Y-%m-%d %H:%M")
 
 
-def _render_table(entries: list[JobHistoryEntry]) -> None:
-    """Render entries as a Rich table (newest first)."""
+def _format_duration(td: timedelta, *, in_progress: bool = False) -> str:
+    """Format ``td`` as ``2h 30m`` / ``45s`` / ``3d 5h``.
+
+    Mirrors :func:`discovery.poll.cli_status._format_duration` semantics
+    so the runtime values line up between ``discovery job list`` and
+    ``discovery job history --status``.
+    """
+    total = int(td.total_seconds())
+    if total < 0:
+        return "0s"
+    days, rem = divmod(total, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, seconds = divmod(rem, 60)
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if seconds or not parts:
+        parts.append(f"{seconds}s")
+    out = " ".join(parts[:2])
+    return out + "+" if in_progress else out
+
+
+# Status categories returned from :func:`get_operation_status` carry
+# both a top-level lifecycle string and a per-execution result with
+# timing. We collapse them into a tiny snapshot dataclass so the
+# renderer doesn't have to know about the API shape.
+@dataclass
+class _StatusSnapshot:
+    """Live status + runtime for one entry, or an explanatory error tag."""
+
+    status: str = ""
+    runtime: str = ""
+    style: str = "white"
+
+
+# Color / style hints for the rendered status cell. Keys are the
+# lowercased status string returned by the API; values are Rich style
+# specs.
+_STATUS_STYLES: dict[str, str] = {
+    "succeeded": "green",
+    "completed": "green",
+    "running": "cyan",
+    "active": "cyan",
+    "pending": "yellow",
+    "notstarted": "yellow",
+    "accepted": "yellow",
+    "failed": "red",
+    "canceled": "magenta",
+    "cancelled": "magenta",
+    "expired": "dim",
+    "?": "dim",
+}
+
+
+def _snapshot_from_response(resp) -> _StatusSnapshot:
+    """Build a :class:`_StatusSnapshot` from a ``ToolExecutionResponse``."""
+    raw_status = (resp.status or "").strip() or "?"
+    style = _STATUS_STYLES.get(raw_status.lower(), "white")
+    result = resp.result
+    runtime = ""
+    if result and result.created_at:
+        end = result.completed_at or datetime.now(tz=timezone.utc)
+        in_progress = result.completed_at is None
+        runtime = _format_duration(end - result.created_at, in_progress=in_progress)
+    return _StatusSnapshot(status=raw_status, runtime=runtime, style=style)
+
+
+def _classify_status_error(op_id: str, exc: httpx.HTTPStatusError) -> _StatusSnapshot:
+    """Map an HTTP error to a snapshot tag."""
+    code = getattr(getattr(exc, "response", None), "status_code", None)
+    if code == 404:
+        return _StatusSnapshot(status="expired", style=_STATUS_STYLES["expired"])
+    debug(f"history --status: HTTP {code} for {op_id}")
+    return _StatusSnapshot(status="?", style=_STATUS_STYLES["?"])
+
+
+def _fetch_status_snapshots(
+    env_cfg,
+    entries: list[JobHistoryEntry],
+    *,
+    workers: int = 16,
+) -> dict[str, _StatusSnapshot]:
+    """Parallel-fetch live status for ``entries``; never raise.
+
+    Each lookup is independent so failures (404, network, etc.) only
+    affect that one row — the rest of the table renders normally with
+    a tagged status cell.
+    """
+    if not entries:
+        return {}
+    pool_size = max(1, min(workers, len(entries)))
+
+    def _one(op_id: str) -> tuple[str, _StatusSnapshot]:
+        try:
+            resp = get_operation_status(
+                env_cfg.project_name,
+                op_id,
+                env_cfg.workspace_url,
+                api_version=env_cfg.api_version,
+            )
+        except httpx.HTTPStatusError as exc:
+            return op_id, _classify_status_error(op_id, exc)
+        except Exception as exc:  # network / timeout / parse
+            debug(f"history --status: lookup failed for {op_id}: {exc}")
+            return op_id, _StatusSnapshot(
+                status="?", style=_STATUS_STYLES["?"]
+            )
+        return op_id, _snapshot_from_response(resp)
+
+    out: dict[str, _StatusSnapshot] = {}
+    with ThreadPoolExecutor(max_workers=pool_size) as pool:
+        for op_id, snap in pool.map(_one, [e.operation_id for e in entries]):
+            out[op_id] = snap
+    return out
+
+
+def _render_table(
+    entries: list[JobHistoryEntry],
+    *,
+    status_map: dict[str, _StatusSnapshot] | None = None,
+) -> None:
+    """Render entries as a Rich table (newest first).
+
+    When ``status_map`` is supplied, two extra columns (Status,
+    Runtime) are appended with live values fetched from the API.
+    """
     table = Table(
         show_header=True,
         header_style="bold cyan",
@@ -83,6 +219,9 @@ def _render_table(entries: list[JobHistoryEntry]) -> None:
     )
     table.add_column("Operation ID", style="white", no_wrap=True)
     table.add_column("Submitted", no_wrap=True, width=18)
+    if status_map is not None:
+        table.add_column("Status", no_wrap=True, width=10)
+        table.add_column("Runtime", no_wrap=True, width=9)
     table.add_column("Mode", no_wrap=True, width=7)
     table.add_column("Project", no_wrap=True, max_width=24, overflow="ellipsis")
     table.add_column("Host", no_wrap=True, max_width=18, overflow="ellipsis")
@@ -95,14 +234,22 @@ def _render_table(entries: list[JobHistoryEntry]) -> None:
         except ValueError:
             ts_str = entry.submitted_at
         mode_style = MODE_STYLES.get(entry.mode, "white")
-        table.add_row(
-            entry.operation_id,
-            ts_str,
-            f"[{mode_style}]{entry.mode}[/{mode_style}]",
-            entry.project_name or "—",
-            entry.hostname or "—",
-            _truncate(entry.command or "—", width=80),
+        cells: list[str] = [entry.operation_id, ts_str]
+        if status_map is not None:
+            snap = status_map.get(entry.operation_id) or _StatusSnapshot(
+                status="?", style=_STATUS_STYLES["?"]
+            )
+            cells.append(f"[{snap.style}]{snap.status}[/{snap.style}]")
+            cells.append(snap.runtime or "—")
+        cells.extend(
+            [
+                f"[{mode_style}]{entry.mode}[/{mode_style}]",
+                entry.project_name or "—",
+                entry.hostname or "—",
+                _truncate(entry.command or "—", width=80),
+            ]
         )
+        table.add_row(*cells)
     console.print(table)
 
 
@@ -138,6 +285,22 @@ def history_command(
     clear_all: bool = typer.Option(
         False, "--clear", help="Delete the entire history file and exit."
     ),
+    status: bool = typer.Option(
+        False,
+        "--status",
+        "-s",
+        help=(
+            "Fetch each entry's current status and computed runtime "
+            "from the Discovery service. Adds two columns to the "
+            "output; one HTTP call per entry (parallelized). Without "
+            "this flag the command stays fully offline."
+        ),
+    ),
+    status_workers: int = typer.Option(
+        16,
+        "--status-workers",
+        help="Parallel workers when --status is set (default: 16).",
+    ),
 ) -> None:
     """List, locate, or wipe the local job-submit history."""
     if show_path:
@@ -154,13 +317,27 @@ def history_command(
         info(f"Removed {removed} history entr{'y' if removed == 1 else 'ies'}.")
         raise typer.Exit(code=EXIT_OK)
 
+    # When --status is set we always need an env_cfg for the API calls.
+    # Otherwise we only load it if the user wants workspace scoping
+    # (and tolerate failure so pure offline use still works).
+    env_cfg = None
     workspace_url: str | None = None
-    if workspace:
+    if status or workspace:
         try:
             env_cfg = load_project_config(get_config_file_path())
             workspace_url = env_cfg.workspace_url or None
         except Exception:
+            env_cfg = None
             workspace_url = None
+    if not workspace:
+        workspace_url = None
+
+    if status and env_cfg is None:
+        info(
+            "[red]--status requires a configured workspace[/red] "
+            "(run `discovery configure` first)."
+        )
+        raise typer.Exit(code=EXIT_BAD_USAGE)
 
     since_dt = _parse_since(since) if since else None
 
@@ -190,7 +367,18 @@ def history_command(
     if limit > 0:
         entries_sorted = entries_sorted[:limit]
 
-    _render_table(entries_sorted)
+    status_map: dict[str, _StatusSnapshot] | None = None
+    if status:
+        info(
+            f"Fetching live status for {len(entries_sorted)} entr"
+            f"{'y' if len(entries_sorted) == 1 else 'ies'} "
+            f"(parallel x {min(status_workers, len(entries_sorted))})…"
+        )
+        status_map = _fetch_status_snapshots(
+            env_cfg, entries_sorted, workers=status_workers
+        )
+
+    _render_table(entries_sorted, status_map=status_map)
     console.print(
         f"\n[dim]{len(entries_sorted)} of {len(entries)} matching entries · "
         f"file: {history_path()}[/dim]"

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_history.py
@@ -20,6 +20,7 @@ from discovery.common.job_history import (
     clear,
     history_path,
     load_history,
+    parse_since,
 )
 from discovery.common.logging import info
 from discovery.poll.cli_helpers import get_config_file_path, load_project_config
@@ -39,26 +40,11 @@ MODE_STYLES = {
 
 
 def _parse_since(value: str) -> datetime:
-    """Parse ``--since`` value: either ``YYYY-MM-DD`` or ``<N><unit>`` shorthand.
-
-    Supported shorthand units: ``h`` (hours), ``d`` (days), ``w`` (weeks).
-    Examples: ``24h``, ``7d``, ``2w``.
-    """
-    value = value.strip()
-    now = datetime.now(tz=timezone.utc)
-    if len(value) >= 2 and value[:-1].isdigit() and value[-1] in {"h", "d", "w"}:
-        n = int(value[:-1])
-        unit = value[-1]
-        if unit == "h":
-            return now - timedelta(hours=n)
-        if unit == "d":
-            return now - timedelta(days=n)
-        return now - timedelta(weeks=n)
+    """Wrapper that converts :class:`ValueError` to ``typer.BadParameter``."""
     try:
-        return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return parse_since(value)
     except ValueError as exc:
-        msg = f"Invalid --since value: {value!r}. Expected YYYY-MM-DD, '24h', '7d', or '2w'."
-        raise typer.BadParameter(msg) from exc
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _truncate(value: str, *, width: int) -> str:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
@@ -23,7 +23,6 @@ from discovery.poll.models.tool_response import AzureCoreOperationState
 from .cli_helpers import (
     emit_env,
     get_config_file_path,
-    get_raw_azure_username,
     load_project_config,
     render_error_with_details,
 )
@@ -71,45 +70,53 @@ def _format_duration(td: timedelta, in_progress: bool = False) -> str:
     return result
 
 
-def _mine_ids_or_exit(env_cfg) -> set[str]:
-    """Return the local-history operation IDs for the current env, or exit gracefully.
+def _mine_ids_or_hint(env_cfg) -> set[str] | None:
+    """Return the local-history operation IDs for the current workspace.
 
-    Scopes by ``workspace_url`` so a user pointing at a different
-    Discovery environment doesn't accidentally see unrelated entries.
-    Exits with code 0 (after a friendly message) when the history is
-    empty for this workspace, so scripts don't have to differentiate
-    "no matches" from "history not yet populated".
+    Returns ``None`` (and prints a one-line hint) when the local
+    history is empty, so callers can degrade to "no matches" without
+    error-exiting. ``None`` means "no filter possible" — the caller
+    typically converts that to a no-results outcome with guidance to
+    pass ``--all``.
     """
     ids = local_operation_ids(workspace_url=env_cfg.workspace_url)
     if not ids:
         info(
             "No locally-recorded jobs found for this workspace yet. "
-            "Submit a job with `discovery job start` (or run with "
-            "DISCOVERY_NO_JOB_HISTORY unset) and try again."
+            "Submit a job with `discovery job start` first, or pass "
+            "[bold]--all[/bold] to see everyone's jobs."
         )
-        raise typer.Exit(code=0)
+        return None
     return ids
 
 
 @app.command("running")
 def list_running(
     limit: int = typer.Option(1000, "--limit", "-n", help="Limit results to search"),
-    all_users: bool = typer.Option(False, "--all", "-a", help="Show jobs from all users"),
-    mine: bool = typer.Option(
+    all_jobs: bool = typer.Option(
         False,
-        "--mine",
-        "-m",
-        help="Only show jobs recorded in this machine's local history",
+        "--all",
+        "-a",
+        help=(
+            "Show every running operation in the workspace, not just those "
+            "submitted from this machine."
+        ),
     ),
 ) -> None:
-    """List running operations (filtered to current user by default)."""
+    """List running operations.
+
+    By default only lists operations recorded in this machine's local
+    job history (see ``discovery job history``). Pass ``--all`` to
+    include jobs submitted by other people or from other machines.
+    """
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
-    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
+    mine_ids = None if all_jobs else _mine_ids_or_hint(env_cfg)
+    if not all_jobs and mine_ids is None:
+        raise typer.Exit(code=0)
     _list_helper(
         status=(AzureCoreOperationState.RUNNING, AzureCoreOperationState.ACTIVE),
         limit=limit,
-        user_filter=None if all_users else get_raw_azure_username(),
         env_cfg=env_cfg,
         mine_ids=mine_ids,
     )
@@ -118,18 +125,27 @@ def list_running(
 @app.command("pending")
 def list_queued(
     limit: int = typer.Option(1000, "--limit", "-n", help="Limit results to search"),
-    all_users: bool = typer.Option(False, "--all", "-a", help="Show jobs from all users"),
-    mine: bool = typer.Option(
+    all_jobs: bool = typer.Option(
         False,
-        "--mine",
-        "-m",
-        help="Only show jobs recorded in this machine's local history",
+        "--all",
+        "-a",
+        help=(
+            "Show every queued operation in the workspace, not just those "
+            "submitted from this machine."
+        ),
     ),
 ) -> None:
-    """List queued operations (filtered to current user by default)."""
+    """List queued operations.
+
+    By default only lists operations recorded in this machine's local
+    job history (see ``discovery job history``). Pass ``--all`` to
+    include jobs submitted by other people or from other machines.
+    """
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
-    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
+    mine_ids = None if all_jobs else _mine_ids_or_hint(env_cfg)
+    if not all_jobs and mine_ids is None:
+        raise typer.Exit(code=0)
     _list_helper(
         status=(
             AzureCoreOperationState.NOT_STARTED,
@@ -137,7 +153,6 @@ def list_queued(
             AzureCoreOperationState.ACCEPTED,
         ),
         limit=limit,
-        user_filter=None if all_users else get_raw_azure_username(),
         env_cfg=env_cfg,
         mine_ids=mine_ids,
     )
@@ -146,17 +161,27 @@ def list_queued(
 @app.command("done")
 def list_done(
     limit: int = typer.Option(200, "--limit", "-n", help="Limit results to search"),
-    mine: bool = typer.Option(
+    all_jobs: bool = typer.Option(
         False,
-        "--mine",
-        "-m",
-        help="Only show jobs recorded in this machine's local history",
+        "--all",
+        "-a",
+        help=(
+            "Show every completed operation in the workspace, not just those "
+            "submitted from this machine."
+        ),
     ),
 ) -> None:
-    """List successful and failed operations."""
+    """List successful and failed operations.
+
+    By default only lists operations recorded in this machine's local
+    job history. Pass ``--all`` to include jobs submitted by other
+    people or from other machines.
+    """
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
-    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
+    mine_ids = None if all_jobs else _mine_ids_or_hint(env_cfg)
+    if not all_jobs and mine_ids is None:
+        raise typer.Exit(code=0)
     _list_helper(
         status=(
             AzureCoreOperationState.FAILED,
@@ -172,22 +197,35 @@ def list_done(
 @app.command("list")
 def list_cmd(
     nodepool: str = typer.Option("", "--pool", help="Filter by nodepool"),
-    user: str = typer.Option("", "--user", help="Filter by user"),
+    user: str = typer.Option("", "--user", help="Filter by user (implies --all)"),
     date: str = typer.Option("", "--date", help="Filter by date (YYYY-MM-DD format)"),
     limit: int = typer.Option(200, "--limit", "-n", help="Limit results to search"),
-    mine: bool = typer.Option(
+    all_jobs: bool = typer.Option(
         False,
-        "--mine",
-        "-m",
-        help="Only show jobs recorded in this machine's local history",
+        "--all",
+        "-a",
+        help=(
+            "Show every operation in the workspace, not just those submitted "
+            "from this machine."
+        ),
     ),
 ) -> None:
-    """List recent operations."""
+    """List recent operations.
+
+    By default only lists operations recorded in this machine's local
+    job history. Pass ``--all`` (or ``--user X`` to filter by a specific
+    user) to see jobs from other people or other machines.
+    """
     debug("list(): entering")
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
 
-    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
+    # ``--user X`` is an explicit cross-user query; implicitly skip the
+    # local-history default so the user actually sees something.
+    skip_mine = all_jobs or bool(user)
+    mine_ids = None if skip_mine else _mine_ids_or_hint(env_cfg)
+    if not skip_mine and mine_ids is None:
+        raise typer.Exit(code=0)
 
     # Resolve --pool to a full resource ID so the filter matches op.nodepool_id
     resolved_pool = ""
@@ -239,7 +277,6 @@ def _list_helper(
     *,
     limit: int = 0,
     page_size: int = 0,
-    user_filter: str | None = None,
     env_cfg=None,
     mine_ids: set[str] | None = None,
 ) -> None:
@@ -250,8 +287,6 @@ def _list_helper(
 
     def matches_status(op):
         if op.status not in status:
-            return False
-        if user_filter and op.created_by != user_filter:
             return False
         return not (mine_ids is not None and op.id not in mine_ids)
 

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
@@ -15,6 +15,7 @@ from rich.status import Status
 from rich.table import Table
 
 from discovery.common.job_history import (
+    load_history,
     local_operation_ids,
 )
 from discovery.common.logging import debug, error, info
@@ -88,6 +89,34 @@ def _mine_ids_or_hint(env_cfg) -> set[str] | None:
         )
         return None
     return ids
+
+
+def _oldest_mine_submission(env_cfg, *, slack: timedelta = timedelta(hours=1)) -> datetime | None:
+    """Return ``min(submitted_at)`` across local history for this workspace.
+
+    Used as a ``not_before`` cutoff for the paginator: operations older
+    than this are guaranteed not to be in the local history (since they
+    would have to predate the very first job we ever recorded here).
+
+    A small ``slack`` is subtracted to account for clock skew between
+    the local machine and the Discovery service — better to scan one
+    extra op than to incorrectly skip a match.
+    """
+    entries = load_history(workspace_url=env_cfg.workspace_url)
+    timestamps: list[datetime] = []
+    for entry in entries:
+        if not entry.submitted_at:
+            continue
+        try:
+            ts = datetime.fromisoformat(entry.submitted_at.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        timestamps.append(ts)
+    if not timestamps:
+        return None
+    return min(timestamps) - slack
 
 
 @app.command("running")
@@ -268,6 +297,8 @@ def list_cmd(
             env_cfg=env_cfg,
             filter_fn=matches_filters,
             limit=limit,
+            target_ids=mine_ids,
+            not_before=_oldest_mine_submission(env_cfg) if mine_ids else None,
         )
     )
 
@@ -296,6 +327,10 @@ def _list_helper(
             filter_fn=matches_status,
             limit=limit,
             page_size=page_size,
+            target_ids=mine_ids,
+            not_before=(
+                _oldest_mine_submission(env_cfg) if mine_ids else None
+            ),
         )
     )
 
@@ -305,12 +340,25 @@ async def _paginated_list(
     filter_fn,
     limit: int = 0,
     page_size: int = 0,
+    target_ids: set[str] | None = None,
+    not_before: datetime | None = None,
 ) -> None:
     """Async implementation of paginated list.
 
     Fetches pages until page_size matching results are collected, then displays
     and asks user if they want to continue. Prefetches next page while waiting
     for user input to reduce perceived latency.
+
+    Args:
+        target_ids: When set, stop paginating as soon as every ID in
+            this set has been matched. Caps the scan when the caller
+            knows in advance the maximum possible result count (e.g.
+            the local-history default filter, where mine_ids is the
+            only thing that can match).
+        not_before: When set, stop paginating as soon as we encounter
+            an operation older than this timestamp. Listings come back
+            newest-first, so anything past this point can't be a
+            match. Naive datetimes are treated as UTC.
     """
     # Auto-detect page size from terminal height if not specified
     if page_size <= 0:
@@ -336,6 +384,16 @@ async def _paginated_list(
         display = np.qualified_name if np.supercomputer_name else np.name
         pool_display[np.id] = display
         pool_display[np.name] = display
+
+    # Normalize ``not_before`` to UTC for safe comparison with op.created_at
+    # (which is timezone-aware per the API model).
+    if not_before is not None and not_before.tzinfo is None:
+        not_before = not_before.replace(tzinfo=timezone.utc)
+
+    # Track which target_ids we've already matched so we can stop paginating
+    # the moment every locally-known ID has been seen.
+    matches_seen: set[str] = set()
+    early_exit = False
 
     def update_spinner() -> None:
         if spinner:
@@ -378,8 +436,20 @@ async def _paginated_list(
                 if latest_time is None or op.created_at > latest_time:
                     latest_time = op.created_at
 
+                # Time-based early-exit: results are newest-first, so once
+                # we cross ``not_before`` no later op can match.
+                if not_before is not None and op.created_at < not_before:
+                    early_exit = True
+                    debug(
+                        f"early-exit: op {op.id} is older than "
+                        f"{not_before.isoformat()}; stopping scan"
+                    )
+                    break
+
                 if filter_fn(op):
                     total_matches += 1
+                    if target_ids is not None:
+                        matches_seen.add(op.id)
                     local_time = op.created_at.astimezone()
                     formatted_time = local_time.strftime("%m-%d %H:%M")
                     completed_time = ""
@@ -397,8 +467,21 @@ async def _paginated_list(
                     raw_pool = op.nodepool_id or ""
                     pool_name = pool_display.get(raw_pool) or pool_display.get(raw_pool.split("/")[-1], raw_pool.split("/")[-1])
                     batch.append((op.id, formatted_time, completed_time, runtime_str, op.created_by, pool_name, op.status))
+
+                    # ID-based early-exit: every target accounted for.
+                    if target_ids is not None and matches_seen >= target_ids:
+                        early_exit = True
+                        debug(
+                            f"early-exit: matched all {len(target_ids)} "
+                            "target ids; stopping scan"
+                        )
+                        break
+
                     if len(batch) >= page_size:
                         break
+
+            if early_exit:
+                break
 
             # Need more results? Fetch next API page
             if len(batch) < page_size and result.next_link and (limit <= 0 or total_api_results < limit):
@@ -462,6 +545,13 @@ async def _paginated_list(
         # Check if we hit the search limit
         if total_api_results >= limit:
             debug(f"Reached search limit of {limit} results.")
+            break
+
+        # Early-exit triggered inside the batch loop (all target ids
+        # matched, or we crossed not_before): stop after displaying
+        # whatever we've collected.
+        if early_exit:
+            debug("Early-exit triggered; stopping pagination loop.")
             break
 
         # Check for more data (either remaining items on current page, or more API pages)

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
@@ -14,6 +14,9 @@ from rich.panel import Panel
 from rich.status import Status
 from rich.table import Table
 
+from discovery.common.job_history import (
+    local_operation_ids,
+)
 from discovery.common.logging import debug, error, info
 from discovery.poll.models.tool_response import AzureCoreOperationState
 
@@ -68,16 +71,47 @@ def _format_duration(td: timedelta, in_progress: bool = False) -> str:
     return result
 
 
+def _mine_ids_or_exit(env_cfg) -> set[str]:
+    """Return the local-history operation IDs for the current env, or exit gracefully.
+
+    Scopes by ``workspace_url`` so a user pointing at a different
+    Discovery environment doesn't accidentally see unrelated entries.
+    Exits with code 0 (after a friendly message) when the history is
+    empty for this workspace, so scripts don't have to differentiate
+    "no matches" from "history not yet populated".
+    """
+    ids = local_operation_ids(workspace_url=env_cfg.workspace_url)
+    if not ids:
+        info(
+            "No locally-recorded jobs found for this workspace yet. "
+            "Submit a job with `discovery job start` (or run with "
+            "DISCOVERY_NO_JOB_HISTORY unset) and try again."
+        )
+        raise typer.Exit(code=0)
+    return ids
+
+
 @app.command("running")
 def list_running(
     limit: int = typer.Option(1000, "--limit", "-n", help="Limit results to search"),
     all_users: bool = typer.Option(False, "--all", "-a", help="Show jobs from all users"),
+    mine: bool = typer.Option(
+        False,
+        "--mine",
+        "-m",
+        help="Only show jobs recorded in this machine's local history",
+    ),
 ) -> None:
     """List running operations (filtered to current user by default)."""
+    env_cfg = load_project_config(get_config_file_path())
+    emit_env(env_cfg)
+    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
     _list_helper(
         status=(AzureCoreOperationState.RUNNING, AzureCoreOperationState.ACTIVE),
         limit=limit,
         user_filter=None if all_users else get_raw_azure_username(),
+        env_cfg=env_cfg,
+        mine_ids=mine_ids,
     )
 
 
@@ -85,8 +119,17 @@ def list_running(
 def list_queued(
     limit: int = typer.Option(1000, "--limit", "-n", help="Limit results to search"),
     all_users: bool = typer.Option(False, "--all", "-a", help="Show jobs from all users"),
+    mine: bool = typer.Option(
+        False,
+        "--mine",
+        "-m",
+        help="Only show jobs recorded in this machine's local history",
+    ),
 ) -> None:
     """List queued operations (filtered to current user by default)."""
+    env_cfg = load_project_config(get_config_file_path())
+    emit_env(env_cfg)
+    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
     _list_helper(
         status=(
             AzureCoreOperationState.NOT_STARTED,
@@ -95,14 +138,25 @@ def list_queued(
         ),
         limit=limit,
         user_filter=None if all_users else get_raw_azure_username(),
+        env_cfg=env_cfg,
+        mine_ids=mine_ids,
     )
 
 
 @app.command("done")
 def list_done(
     limit: int = typer.Option(200, "--limit", "-n", help="Limit results to search"),
+    mine: bool = typer.Option(
+        False,
+        "--mine",
+        "-m",
+        help="Only show jobs recorded in this machine's local history",
+    ),
 ) -> None:
     """List successful and failed operations."""
+    env_cfg = load_project_config(get_config_file_path())
+    emit_env(env_cfg)
+    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
     _list_helper(
         status=(
             AzureCoreOperationState.FAILED,
@@ -110,6 +164,8 @@ def list_done(
             AzureCoreOperationState.CANCELED,
         ),
         limit=limit,
+        env_cfg=env_cfg,
+        mine_ids=mine_ids,
     )
 
 
@@ -119,11 +175,19 @@ def list_cmd(
     user: str = typer.Option("", "--user", help="Filter by user"),
     date: str = typer.Option("", "--date", help="Filter by date (YYYY-MM-DD format)"),
     limit: int = typer.Option(200, "--limit", "-n", help="Limit results to search"),
+    mine: bool = typer.Option(
+        False,
+        "--mine",
+        "-m",
+        help="Only show jobs recorded in this machine's local history",
+    ),
 ) -> None:
     """List recent operations."""
     debug("list(): entering")
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
+
+    mine_ids = _mine_ids_or_exit(env_cfg) if mine else None
 
     # Resolve --pool to a full resource ID so the filter matches op.nodepool_id
     resolved_pool = ""
@@ -149,6 +213,8 @@ def list_cmd(
             raise typer.Exit(code=1) from None
 
     def matches_filters(op):
+        if mine_ids is not None and op.id not in mine_ids:
+            return False
         if user and op.created_by != user:
             return False
         if resolved_pool and op.nodepool_id != resolved_pool:
@@ -174,17 +240,20 @@ def _list_helper(
     limit: int = 0,
     page_size: int = 0,
     user_filter: str | None = None,
+    env_cfg=None,
+    mine_ids: set[str] | None = None,
 ) -> None:
     """Helper for listing operations by status with interactive pagination."""
-    env_cfg = load_project_config(get_config_file_path())
-    emit_env(env_cfg)
+    if env_cfg is None:
+        env_cfg = load_project_config(get_config_file_path())
+        emit_env(env_cfg)
 
     def matches_status(op):
         if op.status not in status:
             return False
         if user_filter and op.created_by != user_filter:
             return False
-        return True
+        return not (mine_ids is not None and op.id not in mine_ids)
 
     asyncio.run(
         _paginated_list(

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -17,6 +17,7 @@ from discovery.common.job_history import (
     MODE_BATCH,
     MODE_START,
     MODE_VSCODE,
+    JobHistoryEntry,
     load_history,
     parse_since,
     record_submission,
@@ -39,6 +40,7 @@ from .cli_helpers import (
     format_service_error,
     get_azure_username,
     get_config_file_path,
+    get_raw_azure_username,
     load_project_config,
     load_tool_config,
     prepare_command,
@@ -63,6 +65,14 @@ def _record_job_submission(
 ) -> None:
     """Append a job-history entry; never raises into the submit flow."""
     try:
+        # ``get_raw_azure_username`` may shell out to ``az`` and may
+        # raise / time out in degraded environments. Whatever happens,
+        # recording is best-effort — we only use the value to scope
+        # later bulk operations to "this Azure principal".
+        try:
+            az_user = get_raw_azure_username() or ""
+        except Exception:
+            az_user = ""
         record_submission(
             operation_id,
             command=command,
@@ -72,6 +82,7 @@ def _record_job_submission(
             workspace_url=getattr(env_cfg, "workspace_url", "") or "",
             mode=mode,
             cli_argv=list(sys.argv),
+            azure_username=az_user,
         )
     except Exception as exc:  # pragma: no cover - defensive
         debug(f"job-history: record_submission swallowed {exc}")
@@ -1207,6 +1218,50 @@ def _cancel_recent(env_cfg, *, since_value: str, yes: bool, parallelism: int) ->
         )
         return
 
+    # Scope to the *current* Azure principal. Local history can contain
+    # entries from other users when ``$HOME`` is shared (shared
+    # workstations, build agents that reauth between users, etc.). We
+    # never want one user's bulk-cancel to reach another's jobs.
+    #
+    # ``get_raw_azure_username`` shells out to ``az`` and may fail in
+    # degraded environments — in that case we degrade to "no filter",
+    # which preserves the previous behavior, but emit a warning so the
+    # user knows what's happening.
+    try:
+        current_az_user = get_raw_azure_username() or ""
+    except Exception as exc:
+        debug(f"cancel --since: az lookup failed: {exc}")
+        current_az_user = ""
+
+    skipped_other_user: list[JobHistoryEntry] = []
+    if current_az_user:
+        kept: list[JobHistoryEntry] = []
+        for entry in entries:
+            recorded = entry.azure_username or ""
+            # Older entries (recorded before the azure_username field
+            # existed) have an empty recorded user. Treat them as
+            # "matches anyone" so backwards compatibility holds — we
+            # have no way to verify them, but they were written by
+            # whoever owned this HOME at the time.
+            if recorded and recorded != current_az_user:
+                skipped_other_user.append(entry)
+                continue
+            kept.append(entry)
+        entries = kept
+        if skipped_other_user:
+            info(
+                f"Skipping {len(skipped_other_user)} entr"
+                f"{'y' if len(skipped_other_user) == 1 else 'ies'} from a "
+                f"different Azure login (current: {current_az_user})."
+            )
+
+    if not entries:
+        info(
+            "No locally-recorded jobs for the current Azure login "
+            f"({current_az_user}) since {cutoff.isoformat()}."
+        )
+        return
+
     # Sort newest-first for the confirmation preview.
     entries_sorted = sorted(
         entries, key=lambda e: e.submitted_at, reverse=True
@@ -1238,50 +1293,63 @@ def _cancel_recent(env_cfg, *, since_value: str, yes: bool, parallelism: int) ->
         info("Cancellation aborted.")
         raise typer.Exit(code=0)
 
+    _run_parallel_cancel(env_cfg, entries_sorted, parallelism=parallelism)
+
+
+def _cancel_one_op(env_cfg, op_id: str) -> tuple[str, str | None]:
+    """Cancel a single op; return ``(op_id, error_message_or_None)``.
+
+    404/409 responses are treated as success — the op is already in a
+    terminal state, so the user's goal ("make it stop") is already true.
+    """
+    try:
+        cancel_operation(
+            env_cfg.project_name,
+            op_id,
+            env_cfg.workspace_url,
+            api_version=env_cfg.api_version,
+        )
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status in (404, 409):
+            return op_id, None
+        return op_id, f"HTTP {status}: {exc.response.text[:120]}"
+    except (httpx.TransportError, PollError) as exc:
+        return op_id, f"{type(exc).__name__}: {exc}"
+    return op_id, None
+
+
+def _run_parallel_cancel(
+    env_cfg,
+    entries: list[JobHistoryEntry],
+    *,
+    parallelism: int,
+) -> None:
+    """Fan out cancel calls across a thread pool; exit 1 on any failure."""
     succeeded: list[str] = []
     failed: list[tuple[str, str]] = []
-
-    def _cancel_one(op_id: str) -> tuple[str, str | None]:
-        try:
-            cancel_operation(
-                env_cfg.project_name,
-                op_id,
-                env_cfg.workspace_url,
-                api_version=env_cfg.api_version,
-            )
-        except httpx.HTTPStatusError as exc:
-            # The op may already be in a terminal state (404 / 409) —
-            # don't treat that as a hard failure since the user's goal
-            # was "make it stop", which is already true.
-            status = exc.response.status_code
-            if status in (404, 409):
-                return op_id, None
-            return op_id, f"HTTP {status}: {exc.response.text[:120]}"
-        except (httpx.TransportError, PollError) as exc:
-            return op_id, f"{type(exc).__name__}: {exc}"
-        return op_id, None
-
-    workers = max(1, min(parallelism, len(entries_sorted)))
-    info(
-        f"Cancelling {len(entries_sorted)} job(s) "
-        f"with {workers} parallel worker(s)…"
-    )
+    total = len(entries)
+    workers = max(1, min(parallelism, total))
+    info(f"Cancelling {total} job(s) with {workers} parallel worker(s)…")
     with ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {
-            pool.submit(_cancel_one, entry.operation_id): entry.operation_id
-            for entry in entries_sorted
+            pool.submit(_cancel_one_op, env_cfg, entry.operation_id):
+                entry.operation_id
+            for entry in entries
         }
         for fut in as_completed(futures):
             op_id, err_msg = fut.result()
             if err_msg is None:
                 succeeded.append(op_id)
-                info(f"  [{len(succeeded) + len(failed)}/{len(entries_sorted)}] ✓ {op_id}")
+                info(f"  [{len(succeeded) + len(failed)}/{total}] ✓ {op_id}")
             else:
                 failed.append((op_id, err_msg))
-                error(f"  [{len(succeeded) + len(failed)}/{len(entries_sorted)}] ✗ {op_id}: {err_msg}")
-
+                error(
+                    f"  [{len(succeeded) + len(failed)}/{total}] ✗ "
+                    f"{op_id}: {err_msg}"
+                )
     info(
-        f"Done. Cancelled {len(succeeded)} of {len(entries_sorted)} job(s)"
+        f"Done. Cancelled {len(succeeded)} of {total} job(s)"
         f"{'; ' + str(len(failed)) + ' failed' if failed else ''}."
     )
     if failed:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -12,6 +13,12 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from discovery.common.job_history import (
+    MODE_BATCH,
+    MODE_START,
+    MODE_VSCODE,
+    record_submission,
+)
 from discovery.common.logging import debug, error, info, pretty_debug
 from discovery.poll.models.api_version import ApiVersion
 from discovery.poll.models.tool_run import (
@@ -39,9 +46,33 @@ from .dataplane_api import (
     PollError,
     cancel_operation,
     get_operation_status,
-    run_and_poll,
+    poll_operation,
     start_tool_run,
 )
+
+
+def _record_job_submission(
+    operation_id: str,
+    env_cfg,
+    *,
+    command: str,
+    nodepool_id: str,
+    mode: str,
+) -> None:
+    """Append a job-history entry; never raises into the submit flow."""
+    try:
+        record_submission(
+            operation_id,
+            command=command,
+            tool_id=getattr(env_cfg, "tool_id", "") or "",
+            nodepool_id=nodepool_id,
+            project_name=getattr(env_cfg, "project_name", "") or "",
+            workspace_url=getattr(env_cfg, "workspace_url", "") or "",
+            mode=mode,
+            cli_argv=list(sys.argv),
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        debug(f"job-history: record_submission swallowed {exc}")
 
 # Backward-compatibility re-exports: the canonical source of truth is
 # :class:`ApiVersion` in ``discovery.poll.models.api_version``. These sets exist so
@@ -525,15 +556,31 @@ def start(
     pretty_debug(payload, label="ToolRunRequest payload")
 
     try:
+        # Submit first, then record locally so the at-exit / list filters
+        # see the operation immediately. ``run_and_poll`` is inlined
+        # here as ``start_tool_run`` + ``poll_operation`` so we can
+        # record between the two calls — that way even Ctrl+C during
+        # polling leaves a usable history entry.
+        response = start_tool_run(
+            env_cfg.project_name,
+            payload,
+            env_cfg.workspace_url,
+            api_version=effective_api_version,
+        )
+        _record_job_submission(
+            response.id,
+            env_cfg,
+            command=command,
+            nodepool_id=effective_nodepool_id,
+            mode=MODE_START,
+        )
         if no_wait:
-            # Submit job and exit without polling
-            response = start_tool_run(env_cfg.project_name, payload, env_cfg.workspace_url, api_version=effective_api_version)
             info(f"Job submitted. Operation ID: {response.id}")
             return
 
-        result = run_and_poll(
+        result = poll_operation(
             env_cfg.project_name,
-            payload,
+            response.id,
             env_cfg.workspace_url,
             poll_interval=DEFAULT_INTERVAL,
             timeout_seconds=DEFAULT_TIMEOUT,
@@ -776,6 +823,13 @@ def batch(
                     outputData=output_mounts,
                 )
             response = start_tool_run(env_cfg.project_name, payload, env_cfg.workspace_url, api_version=effective_api_version)
+            _record_job_submission(
+                response.id,
+                env_cfg,
+                command=cmd,
+                nodepool_id=effective_nodepool_id,
+                mode=MODE_BATCH,
+            )
             return (idx, response.id, None)
         except Exception as e:
             return (idx, None, str(e))
@@ -997,6 +1051,13 @@ def vscode_cmd(
     # Submit job without polling
     try:
         response = start_tool_run(env_cfg.project_name, payload, env_cfg.workspace_url, api_version=effective_api_version)
+        _record_job_submission(
+            response.id,
+            env_cfg,
+            command=f"<vscode tunnel: {tunnel_name}>",
+            nodepool_id=effective_nodepool_id,
+            mode=MODE_VSCODE,
+        )
     except httpx.HTTPStatusError as exc:
         error(format_service_error(exc))
         raise typer.Exit(code=1) from exc

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -17,6 +17,8 @@ from discovery.common.job_history import (
     MODE_BATCH,
     MODE_START,
     MODE_VSCODE,
+    load_history,
+    parse_since,
     record_submission,
 )
 from discovery.common.logging import debug, error, info, pretty_debug
@@ -1114,12 +1116,63 @@ def vscode_cmd(
 
 @app.command()
 def cancel(
-    operation_id: str = typer.Argument(..., help="Existing operation id to cancel"),
+    operation_id: str = typer.Argument(
+        None,
+        help=(
+            "Existing operation id to cancel. Omit when using --since to "
+            "bulk-cancel from local history."
+        ),
+    ),
+    since: str = typer.Option(
+        "",
+        "--since",
+        help=(
+            "Bulk-cancel every job submitted from this machine within the "
+            "given window. Accepts shorthand like '10m', '1h', '24h', '7d' "
+            "or an absolute YYYY-MM-DD date. Scoped to the current "
+            "workspace_url so a typo doesn't reach into a different "
+            "Discovery environment."
+        ),
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the interactive confirmation prompt.",
+    ),
+    parallelism: int = typer.Option(
+        16,
+        "--parallel",
+        "-p",
+        help="Parallel cancel workers when --since is set (default: 16).",
+    ),
 ) -> None:
-    """Request cancellation of a running operation and optionally wait for terminal state."""
+    """Cancel a running operation, or bulk-cancel recent local submissions.
+
+    Two modes:
+
+    * ``discovery job cancel <operation-id>`` — cancel a single specific op.
+    * ``discovery job cancel --since 10m`` — cancel every locally-recorded
+      job submitted in the last 10 minutes (current workspace only).
+    """
     debug("cancel(): entering")
+
+    if not operation_id and not since:
+        error(
+            "Provide either an operation id or --since DURATION "
+            "(e.g. `discovery job cancel --since 10m`)."
+        )
+        raise typer.Exit(code=2)
+    if operation_id and since:
+        error("--since is mutually exclusive with a positional operation id.")
+        raise typer.Exit(code=2)
+
     env_cfg = load_project_config(get_config_file_path())
     emit_env(env_cfg)
+
+    if since:
+        _cancel_recent(env_cfg, since_value=since, yes=yes, parallelism=parallelism)
+        return
 
     info(f"Cancel requested for operation id={operation_id}")
     try:
@@ -1133,6 +1186,106 @@ def cancel(
     except PollError as exc:
         error(f"Operation failed: {exc}")
         raise typer.Exit(code=1) from exc
+
+
+def _cancel_recent(env_cfg, *, since_value: str, yes: bool, parallelism: int) -> None:
+    """Implement ``discovery job cancel --since DURATION``."""
+    try:
+        cutoff = parse_since(since_value)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(code=2) from exc
+
+    entries = load_history(
+        workspace_url=env_cfg.workspace_url,
+        since=cutoff,
+    )
+    if not entries:
+        info(
+            f"No locally-recorded jobs submitted since {cutoff.isoformat()} "
+            f"in workspace {env_cfg.workspace_url}. Nothing to cancel."
+        )
+        return
+
+    # Sort newest-first for the confirmation preview.
+    entries_sorted = sorted(
+        entries, key=lambda e: e.submitted_at, reverse=True
+    )
+
+    console = Console()
+    console.print()
+    console.print(
+        f"[bold]Will cancel {len(entries_sorted)} job"
+        f"{'s' if len(entries_sorted) != 1 else ''}[/bold] submitted since "
+        f"[cyan]{cutoff.isoformat()}[/cyan]:"
+    )
+    preview_n = min(10, len(entries_sorted))
+    for entry in entries_sorted[:preview_n]:
+        cmd_preview = entry.command or "<no command recorded>"
+        if len(cmd_preview) > 72:
+            cmd_preview = cmd_preview[:71] + "…"
+        console.print(
+            f"  [cyan]{entry.operation_id}[/cyan]  "
+            f"[dim]{entry.submitted_at}[/dim]  {cmd_preview}"
+        )
+    if len(entries_sorted) > preview_n:
+        console.print(
+            f"  [dim]… and {len(entries_sorted) - preview_n} more[/dim]"
+        )
+    console.print()
+
+    if not yes and not typer.confirm("Proceed with cancellation?", default=False):
+        info("Cancellation aborted.")
+        raise typer.Exit(code=0)
+
+    succeeded: list[str] = []
+    failed: list[tuple[str, str]] = []
+
+    def _cancel_one(op_id: str) -> tuple[str, str | None]:
+        try:
+            cancel_operation(
+                env_cfg.project_name,
+                op_id,
+                env_cfg.workspace_url,
+                api_version=env_cfg.api_version,
+            )
+        except httpx.HTTPStatusError as exc:
+            # The op may already be in a terminal state (404 / 409) —
+            # don't treat that as a hard failure since the user's goal
+            # was "make it stop", which is already true.
+            status = exc.response.status_code
+            if status in (404, 409):
+                return op_id, None
+            return op_id, f"HTTP {status}: {exc.response.text[:120]}"
+        except (httpx.TransportError, PollError) as exc:
+            return op_id, f"{type(exc).__name__}: {exc}"
+        return op_id, None
+
+    workers = max(1, min(parallelism, len(entries_sorted)))
+    info(
+        f"Cancelling {len(entries_sorted)} job(s) "
+        f"with {workers} parallel worker(s)…"
+    )
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_cancel_one, entry.operation_id): entry.operation_id
+            for entry in entries_sorted
+        }
+        for fut in as_completed(futures):
+            op_id, err_msg = fut.result()
+            if err_msg is None:
+                succeeded.append(op_id)
+                info(f"  [{len(succeeded) + len(failed)}/{len(entries_sorted)}] ✓ {op_id}")
+            else:
+                failed.append((op_id, err_msg))
+                error(f"  [{len(succeeded) + len(failed)}/{len(entries_sorted)}] ✗ {op_id}: {err_msg}")
+
+    info(
+        f"Done. Cancelled {len(succeeded)} of {len(entries_sorted)} job(s)"
+        f"{'; ' + str(len(failed)) + ' failed' if failed else ''}."
+    )
+    if failed:
+        raise typer.Exit(code=1)
 
 
 __all__ = ["app", "batch", "cancel", "start", "vscode_cmd"]

--- a/utilities/supercomputer-cli/discovery/tests/conftest.py
+++ b/utilities/supercomputer-cli/discovery/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from discovery.common import logging as disc_logging
@@ -24,3 +26,18 @@ def reset_logging_console():
     yield
     disc_logging._STATE.console = None
     disc_logging._STATE.file_logger = None
+
+
+@pytest.fixture(autouse=True)
+def isolate_job_history(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Redirect ``~/.discovery`` writes to a per-test tmp directory.
+
+    Prevents tests from accidentally polluting the developer's real
+    job-history file when they exercise CLI commands that invoke the
+    submit / history paths.
+    """
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    monkeypatch.setattr(
+        "discovery.common.job_history.get_home_dir", lambda: fake_home
+    )

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
@@ -110,7 +110,9 @@ class TestStartCommand:
                             with patch.object(
                                 cli_submit, "prepare_command", return_value="echo test"
                             ):
-                                with patch.object(cli_submit, "run_and_poll") as mock_poll:
+                                with patch.object(cli_submit, "start_tool_run") as mock_start, \
+                                     patch.object(cli_submit, "poll_operation") as mock_poll:
+                                    mock_start.return_value = MagicMock(id="op-test")
                                     mock_result = MagicMock()
                                     mock_result.status = "Completed"
                                     mock_result.result = MagicMock(runtime_details="details")

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -158,8 +158,12 @@ class TestHistoryCommand:
 # ---------------------------------------------------------------------------
 
 
-class TestMineFilter:
-    def test_mine_exits_friendly_when_history_empty(
+class TestDefaultMineBehavior:
+    """`discovery job list / running / pending / done` should default to
+    showing only this machine's locally-recorded jobs, and `--all`
+    should opt out of that filter."""
+
+    def test_running_default_hints_when_history_empty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         fake_cfg = MagicMock()
@@ -175,14 +179,14 @@ class TestMineFilter:
         monkeypatch.setattr(
             "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
         )
-        result = runner.invoke(app, ["job", "running", "--mine"])
+        result = runner.invoke(app, ["job", "running"])
         assert result.exit_code == 0
         assert "No locally-recorded jobs" in result.stdout
+        assert "--all" in result.stdout
 
-    def test_list_mine_invokes_paginator_with_mine_filter(
+    def test_list_default_filters_to_local_history(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Seed history for the configured workspace.
         _seed_history(workspace="https://ws.example")
         fake_cfg = MagicMock()
         fake_cfg.workspace_url = "https://ws.example"
@@ -207,27 +211,124 @@ class TestMineFilter:
         monkeypatch.setattr(
             "discovery.poll.cli_status._paginated_list", fake_paginated
         )
-        result = runner.invoke(app, ["job", "list", "--mine"])
+        # No --all => default to local history.
+        result = runner.invoke(app, ["job", "list"])
         assert result.exit_code == 0
 
         fn = captured["filter_fn"]
-        # op-1 and op-2 are in history; op-3 (other workspace) is not.
-        op_known = MagicMock(
+        op_in_history = MagicMock(
             id="op-1",
             created_by="someone",
             nodepool_id="x",
             created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
         )
-        op_unknown = MagicMock(
-            id="op-3",
+        op_outside_history = MagicMock(
+            id="op-99",
             created_by="someone",
             nodepool_id="x",
             created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
         )
-        assert fn(op_known) is True
-        assert fn(op_unknown) is False
+        assert fn(op_in_history) is True
+        assert fn(op_outside_history) is False
 
-    def test_running_mine_invokes_paginator_with_mine_filter(
+    def test_list_all_skips_local_history_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_history(workspace="https://ws.example")
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+
+        captured = {}
+
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+            captured["filter_fn"] = filter_fn
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status._paginated_list", fake_paginated
+        )
+        result = runner.invoke(app, ["job", "list", "--all"])
+        assert result.exit_code == 0
+
+        fn = captured["filter_fn"]
+        # Both ops match — local-history filter is disabled.
+        op_in = MagicMock(
+            id="op-1",
+            created_by="x",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        op_out = MagicMock(
+            id="op-99",
+            created_by="x",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        assert fn(op_in) is True
+        assert fn(op_out) is True
+
+    def test_list_user_flag_implies_all(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--user X`` is a cross-user query, so the local-history
+        default should be skipped automatically."""
+        _seed_history(workspace="https://ws.example")
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+
+        captured = {}
+
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+            captured["filter_fn"] = filter_fn
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status._paginated_list", fake_paginated
+        )
+        result = runner.invoke(app, ["job", "list", "--user", "someone"])
+        assert result.exit_code == 0
+
+        fn = captured["filter_fn"]
+        # op-99 is NOT in local history, but --user implies --all so the
+        # only effective filter is created_by="someone".
+        op_match = MagicMock(
+            id="op-99",
+            created_by="someone",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        op_no_match = MagicMock(
+            id="op-99",
+            created_by="other",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        assert fn(op_match) is True
+        assert fn(op_no_match) is False
+
+    def test_running_default_filters_to_local_history(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _seed_history(workspace="https://ws.example")
@@ -253,24 +354,66 @@ class TestMineFilter:
         monkeypatch.setattr(
             "discovery.poll.cli_status._paginated_list", fake_paginated
         )
-        # ``--all`` disables the per-user filter so the only thing the
-        # filter_fn ends up applying is the mine_ids set we care about.
-        result = runner.invoke(app, ["job", "running", "--mine", "--all"])
+        # No --all => default to local history (no Azure-user filter).
+        result = runner.invoke(app, ["job", "running"])
         assert result.exit_code == 0
 
         fn = captured["filter_fn"]
         op = MagicMock(
             id="op-1",
-            created_by="me",
+            created_by="someone-else",  # not the current Azure user
             status=AzureCoreOperationState.RUNNING,
         )
+        # Should match — default no longer filters by Azure user, only
+        # by local history.
         assert fn(op) is True
         op_other = MagicMock(
             id="not-in-history",
-            created_by="me",
+            created_by="someone-else",
             status=AzureCoreOperationState.RUNNING,
         )
         assert fn(op_other) is False
+
+    def test_running_all_includes_other_machines_jobs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_history(workspace="https://ws.example")
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+
+        captured = {}
+
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+            captured["filter_fn"] = filter_fn
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status._paginated_list", fake_paginated
+        )
+        result = runner.invoke(app, ["job", "running", "--all"])
+        assert result.exit_code == 0
+
+        fn = captured["filter_fn"]
+        op_local = MagicMock(
+            id="op-1",
+            status=AzureCoreOperationState.RUNNING,
+        )
+        op_remote = MagicMock(
+            id="not-in-history",
+            status=AzureCoreOperationState.RUNNING,
+        )
+        assert fn(op_local) is True
+        assert fn(op_remote) is True
 
 
 # ---------------------------------------------------------------------------

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -6,7 +6,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
+from rich.console import Console as _RichConsole
 from typer.testing import CliRunner
 
 from discovery.common import job_history
@@ -151,6 +153,186 @@ class TestHistoryCommand:
         result = runner.invoke(app, ["job", "history", "--clear"], input="y\n")
         assert result.exit_code == 0
         assert not job_history.history_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# `discovery job history --status`
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryStatusFlag:
+    """``--status`` enriches the table with live status + runtime."""
+
+    @pytest.fixture(autouse=True)
+    def _wide_console(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Force a wide console so Rich doesn't truncate the table.
+
+        Without this, ``CliRunner``'s captured stdout reports an 80-col
+        terminal and Rich wraps / hides cells we want to assert on.
+        """
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.console",
+            _RichConsole(width=200, highlight=False, soft_wrap=False),
+        )
+
+    def _setup_env(self, monkeypatch: pytest.MonkeyPatch, workspace: str) -> None:
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = workspace
+        fake_cfg.project_name = "demo"
+        fake_cfg.api_version = "x"
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+
+    def _fake_get_status(self, mapping: dict):
+        """Build a fake get_operation_status that returns a stubbed response
+        per op-id from ``mapping`` (id -> (status, created_at, completed_at))."""
+        def _fn(project, op_id, workspace, *, api_version):
+            entry = mapping.get(op_id)
+            if entry is None:
+                # Simulate 404 with a real httpx.Response so the
+                # status_code attribute access goes through httpx's own
+                # logic rather than MagicMock's attribute autocreation.
+                req = httpx.Request("GET", "https://example/op")
+                resp = httpx.Response(404, request=req)
+                msg = "not found"
+                raise httpx.HTTPStatusError(
+                    msg, request=req, response=resp
+                )
+            status, created_at, completed_at = entry
+            r = MagicMock()
+            r.status = status
+            r.result = MagicMock()
+            r.result.created_at = created_at
+            r.result.completed_at = completed_at
+            return r
+        return _fn
+
+    def test_status_renders_runtime_for_completed_op(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        _seed_history(workspace=ws)
+        self._setup_env(monkeypatch, ws)
+
+        created = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+        completed = created + timedelta(minutes=42, seconds=15)
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_operation_status",
+            self._fake_get_status({
+                "op-1": ("Succeeded", created, completed),
+                "op-2": ("Succeeded", created, completed),
+            }),
+        )
+
+        result = runner.invoke(
+            app, ["job", "history", "--status"]
+        )
+        assert result.exit_code == 0
+        # Both rows must appear with a status + runtime cell.
+        assert "Succeeded" in result.stdout
+        # Runtime should render as "42m 15s" (two most-significant units).
+        assert "42m 15s" in result.stdout
+
+    def test_status_handles_running_ops(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        job_history.record_submission(
+            "op-running",
+            workspace_url=ws,
+            project_name="demo",
+            command="long job",
+            submitted_at="2026-06-01T11:00:00Z",
+        )
+        self._setup_env(monkeypatch, ws)
+
+        # In-progress: created_at set, completed_at None.
+        created = datetime.now(tz=timezone.utc) - timedelta(minutes=5)
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_operation_status",
+            self._fake_get_status({
+                "op-running": ("Running", created, None),
+            }),
+        )
+
+        result = runner.invoke(app, ["job", "history", "--status"])
+        assert result.exit_code == 0
+        assert "Running" in result.stdout
+        # In-progress runtime ends with the "+" suffix.
+        assert "+" in result.stdout
+
+    def test_status_handles_404_as_expired(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        job_history.record_submission(
+            "op-gone",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at="2026-01-01T00:00:00Z",
+        )
+        self._setup_env(monkeypatch, ws)
+        # Empty mapping → every lookup hits the simulated 404 path.
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_operation_status",
+            self._fake_get_status({}),
+        )
+
+        result = runner.invoke(app, ["job", "history", "--status"])
+        assert result.exit_code == 0
+        assert "expired" in result.stdout
+
+    def test_status_handles_network_errors_gracefully(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        job_history.record_submission(
+            "op-offline",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at="2026-06-01T11:00:00Z",
+        )
+        self._setup_env(monkeypatch, ws)
+
+        def boom(*_a, **_kw):
+            msg = "no network"
+            raise httpx.ConnectError(msg)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_operation_status", boom
+        )
+        result = runner.invoke(app, ["job", "history", "--status"])
+        # Network errors do NOT fail the command — they just mark the row.
+        assert result.exit_code == 0
+        # The status column shows "?" when we can't reach the API.
+        assert "?" in result.stdout
+
+    def test_status_default_off_keeps_offline_behavior(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --status the command must not hit the API at all."""
+        ws = "https://ws.example"
+        _seed_history(workspace=ws)
+        self._setup_env(monkeypatch, ws)
+        called = []
+
+        def fail(*_a, **_kw):
+            called.append(_a)
+            msg = "get_operation_status must not be called"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_operation_status", fail
+        )
+        result = runner.invoke(app, ["job", "history"])
+        assert result.exit_code == 0
+        assert called == []
 
 
 # ---------------------------------------------------------------------------
@@ -869,8 +1051,6 @@ class TestCancelSince:
         """If the op is already in a terminal state the service returns
         404/409 — the user's goal ("make it stop") is already true, so
         don't fail the command."""
-        import httpx
-
         ws = "https://ws.example"
         now = datetime.now(tz=timezone.utc)
         job_history.record_submission(

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -614,7 +614,7 @@ class TestCancelSince:
         )
         return called
 
-    def _setup_env(self, monkeypatch: pytest.MonkeyPatch, workspace: str):
+    def _setup_env(self, monkeypatch: pytest.MonkeyPatch, workspace: str, *, az_user: str = "alice@example.com"):
         fake_cfg = MagicMock()
         fake_cfg.workspace_url = workspace
         fake_cfg.project_name = "demo"
@@ -630,6 +630,13 @@ class TestCancelSince:
         )
         monkeypatch.setattr(
             "discovery.poll.cli_submit.emit_env", lambda *_a, **_k: None
+        )
+        # The cancel path looks up the current Azure principal to scope
+        # the filter to "this user only". Tests must stub this to keep
+        # the behavior deterministic.
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.get_raw_azure_username",
+            lambda: az_user,
         )
 
     def test_requires_either_op_id_or_since(
@@ -668,7 +675,8 @@ class TestCancelSince:
     ) -> None:
         ws = "https://ws.example"
         # Two recent (within 5m) submissions, one old (an hour ago),
-        # and one from a different workspace.
+        # and one from a different workspace. All belong to the same
+        # current Azure user.
         now = datetime.now(tz=timezone.utc)
         recent_iso = (
             (now - timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
@@ -682,6 +690,7 @@ class TestCancelSince:
             project_name="demo",
             submitted_at=recent_iso,
             command="recent 1",
+            azure_username="alice@example.com",
         )
         job_history.record_submission(
             "op-recent-2",
@@ -689,6 +698,7 @@ class TestCancelSince:
             project_name="demo",
             submitted_at=recent_iso,
             command="recent 2",
+            azure_username="alice@example.com",
         )
         job_history.record_submission(
             "op-old",
@@ -696,6 +706,7 @@ class TestCancelSince:
             project_name="demo",
             submitted_at=old_iso,
             command="too old",
+            azure_username="alice@example.com",
         )
         job_history.record_submission(
             "op-other-ws",
@@ -703,9 +714,10 @@ class TestCancelSince:
             project_name="demo",
             submitted_at=recent_iso,
             command="other workspace",
+            azure_username="alice@example.com",
         )
 
-        self._setup_env(monkeypatch, ws)
+        self._setup_env(monkeypatch, ws, az_user="alice@example.com")
         called = self._patch_cancel(monkeypatch)
 
         result = runner.invoke(
@@ -714,7 +726,118 @@ class TestCancelSince:
         )
         assert result.exit_code == 0
         assert sorted(called) == ["op-recent-1", "op-recent-2"]
-        assert "op-old" not in result.stdout or "✗ op-old" not in result.stdout
+
+    def test_skips_jobs_from_other_azure_user(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shared $HOME, different az logins: cancel must skip any
+        entry recorded under a different Azure principal."""
+        ws = "https://ws.example"
+        now = datetime.now(tz=timezone.utc)
+        recent = (now - timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+
+        # alice's recent job
+        job_history.record_submission(
+            "op-alice",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent,
+            command="alice's job",
+            azure_username="alice@example.com",
+        )
+        # bob's recent job, also recorded into this shared history file
+        job_history.record_submission(
+            "op-bob",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent,
+            command="bob's job",
+            azure_username="bob@example.com",
+        )
+
+        # We're currently signed in as alice — bob's op must not be touched.
+        self._setup_env(monkeypatch, ws, az_user="alice@example.com")
+        called = self._patch_cancel(monkeypatch)
+
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "10m", "--yes"]
+        )
+        assert result.exit_code == 0
+        assert called == ["op-alice"]
+        assert "Skipping 1 entry" in result.stdout
+        assert "bob@example.com" not in result.stdout  # we don't leak other users' identities
+
+    def test_includes_legacy_entries_with_no_azure_username(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entries written before the azure_username field existed
+        should still be eligible — we have no way to verify them so we
+        treat them as 'whoever owns this HOME'."""
+        ws = "https://ws.example"
+        now = datetime.now(tz=timezone.utc)
+        recent = (now - timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+
+        # Hand-written entry mimicking a pre-azure-username record:
+        # empty azure_username field.
+        job_history.record_submission(
+            "op-legacy",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent,
+            command="legacy entry",
+            azure_username="",
+        )
+
+        self._setup_env(monkeypatch, ws, az_user="alice@example.com")
+        called = self._patch_cancel(monkeypatch)
+
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "10m", "--yes"]
+        )
+        assert result.exit_code == 0
+        assert called == ["op-legacy"]
+
+    def test_falls_back_when_az_lookup_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If we can't determine the current Azure user, degrade to
+        the previous behavior (cancel everything) rather than refusing
+        to do anything."""
+        ws = "https://ws.example"
+        now = datetime.now(tz=timezone.utc)
+        recent = (now - timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+        job_history.record_submission(
+            "op-alice",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent,
+            azure_username="alice@example.com",
+        )
+        job_history.record_submission(
+            "op-bob",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent,
+            azure_username="bob@example.com",
+        )
+
+        self._setup_env(monkeypatch, ws)
+        # Override the stub from _setup_env to simulate a failed az lookup.
+        def boom():
+            msg = "az missing"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.get_raw_azure_username", boom
+        )
+        called = self._patch_cancel(monkeypatch)
+
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "10m", "--yes"]
+        )
+        assert result.exit_code == 0
+        # No filter possible → both ops cancelled (previous behavior).
+        assert sorted(called) == ["op-alice", "op-bob"]
 
     def test_decline_confirmation_aborts(
         self, monkeypatch: pytest.MonkeyPatch

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -594,6 +594,202 @@ class TestPaginatorEarlyExit:
         assert page_calls == []
 
 
+# ---------------------------------------------------------------------------
+# `discovery job cancel --since`
+# ---------------------------------------------------------------------------
+
+
+class TestCancelSince:
+    """Bulk-cancel mode: ``discovery job cancel --since DURATION``."""
+
+    def _patch_cancel(self, monkeypatch: pytest.MonkeyPatch):
+        """Install a no-op cancel_operation that records the IDs it was called with."""
+        called: list[str] = []
+
+        def fake_cancel(project, op_id, workspace_url, *, api_version):
+            called.append(op_id)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.cancel_operation", fake_cancel
+        )
+        return called
+
+    def _setup_env(self, monkeypatch: pytest.MonkeyPatch, workspace: str):
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = workspace
+        fake_cfg.project_name = "demo"
+        fake_cfg.api_version = "x"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.emit_env", lambda *_a, **_k: None
+        )
+
+    def test_requires_either_op_id_or_since(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup_env(monkeypatch, "https://ws.example")
+        result = runner.invoke(app, ["job", "cancel"])
+        assert result.exit_code == 2
+
+    def test_op_id_and_since_are_mutually_exclusive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup_env(monkeypatch, "https://ws.example")
+        result = runner.invoke(
+            app, ["job", "cancel", "op-abc", "--since", "10m"]
+        )
+        assert result.exit_code == 2
+
+    def test_no_matches_exits_zero_with_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # History exists, but cutoff makes nothing match.
+        _seed_history(workspace="https://ws.example")
+        self._setup_env(monkeypatch, "https://ws.example")
+        called = self._patch_cancel(monkeypatch)
+
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "1s", "--yes"]
+        )
+        assert result.exit_code == 0
+        assert "No locally-recorded jobs" in result.stdout
+        assert called == []
+
+    def test_cancels_only_recent_local_history(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        # Two recent (within 5m) submissions, one old (an hour ago),
+        # and one from a different workspace.
+        now = datetime.now(tz=timezone.utc)
+        recent_iso = (
+            (now - timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+        )
+        old_iso = (
+            (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        )
+        job_history.record_submission(
+            "op-recent-1",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent_iso,
+            command="recent 1",
+        )
+        job_history.record_submission(
+            "op-recent-2",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=recent_iso,
+            command="recent 2",
+        )
+        job_history.record_submission(
+            "op-old",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=old_iso,
+            command="too old",
+        )
+        job_history.record_submission(
+            "op-other-ws",
+            workspace_url="https://other.example",
+            project_name="demo",
+            submitted_at=recent_iso,
+            command="other workspace",
+        )
+
+        self._setup_env(monkeypatch, ws)
+        called = self._patch_cancel(monkeypatch)
+
+        result = runner.invoke(
+            app,
+            ["job", "cancel", "--since", "10m", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert sorted(called) == ["op-recent-1", "op-recent-2"]
+        assert "op-old" not in result.stdout or "✗ op-old" not in result.stdout
+
+    def test_decline_confirmation_aborts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ws = "https://ws.example"
+        now = datetime.now(tz=timezone.utc)
+        job_history.record_submission(
+            "op-recent",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=(now - timedelta(minutes=2))
+            .isoformat()
+            .replace("+00:00", "Z"),
+        )
+        self._setup_env(monkeypatch, ws)
+        called = self._patch_cancel(monkeypatch)
+
+        # Pipe 'n' to the confirm prompt.
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "10m"], input="n\n"
+        )
+        assert result.exit_code == 0
+        assert "aborted" in result.stdout.lower()
+        assert called == []
+
+    def test_treats_404_as_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the op is already in a terminal state the service returns
+        404/409 — the user's goal ("make it stop") is already true, so
+        don't fail the command."""
+        import httpx
+
+        ws = "https://ws.example"
+        now = datetime.now(tz=timezone.utc)
+        job_history.record_submission(
+            "op-already-done",
+            workspace_url=ws,
+            project_name="demo",
+            submitted_at=(now - timedelta(minutes=1))
+            .isoformat()
+            .replace("+00:00", "Z"),
+        )
+        self._setup_env(monkeypatch, ws)
+
+        def fake_cancel(*_a, **_kw):
+            resp = MagicMock()
+            resp.status_code = 404
+            resp.text = "not found"
+            msg = "404"
+            raise httpx.HTTPStatusError(
+                msg, request=MagicMock(), response=resp
+            )
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.cancel_operation", fake_cancel
+        )
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "10m", "--yes"]
+        )
+        assert result.exit_code == 0
+        # The op shows in the succeeded summary, not failed.
+        assert "1 of 1" in result.stdout
+        assert "failed" not in result.stdout.lower()
+
+    def test_invalid_since_value_exits_2(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup_env(monkeypatch, "https://ws.example")
+        result = runner.invoke(
+            app, ["job", "cancel", "--since", "not-a-duration"]
+        )
+        assert result.exit_code == 2
+
+
 class TestRecorderIntegration:
     """Verify the recorder helper writes a usable record on a fake submit."""
 

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -205,7 +205,7 @@ class TestDefaultMineBehavior:
 
         captured = {}
 
-        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0, target_ids=None, not_before=None):
             captured["filter_fn"] = filter_fn
 
         monkeypatch.setattr(
@@ -252,7 +252,7 @@ class TestDefaultMineBehavior:
 
         captured = {}
 
-        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0, target_ids=None, not_before=None):
             captured["filter_fn"] = filter_fn
 
         monkeypatch.setattr(
@@ -301,7 +301,7 @@ class TestDefaultMineBehavior:
 
         captured = {}
 
-        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0, target_ids=None, not_before=None):
             captured["filter_fn"] = filter_fn
 
         monkeypatch.setattr(
@@ -348,7 +348,7 @@ class TestDefaultMineBehavior:
 
         captured = {}
 
-        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0, target_ids=None, not_before=None):
             captured["filter_fn"] = filter_fn
 
         monkeypatch.setattr(
@@ -394,7 +394,7 @@ class TestDefaultMineBehavior:
 
         captured = {}
 
-        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0, target_ids=None, not_before=None):
             captured["filter_fn"] = filter_fn
 
         monkeypatch.setattr(
@@ -419,6 +419,179 @@ class TestDefaultMineBehavior:
 # ---------------------------------------------------------------------------
 # Submit-site integration
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Paginator early-exit (target_ids + not_before)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginatorEarlyExit:
+    """When the local-history filter is in effect the paginator should
+    stop pulling pages as soon as it has matched every locally-known
+    ID, and also stop when it scans past the oldest known submission."""
+
+    def _make_op(self, op_id: str, *, age_seconds: int = 0):
+        """Build a minimal OperationsResultModel-shaped mock."""
+        op = MagicMock()
+        op.id = op_id
+        op.created_at = datetime.now(tz=timezone.utc) - timedelta(seconds=age_seconds)
+        op.completed_at = None
+        op.created_by = "someone"
+        op.nodepool_id = "x"
+        op.status = "Running"
+        return op
+
+    def _make_page(self, ops, next_link=None):
+        page = MagicMock()
+        page.values = ops
+        page.next_link = next_link
+        return page
+
+    def test_stops_after_matching_all_target_ids(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two ops on the first page match the local-history set; no
+        further API pages should be fetched even though next_link is
+        present."""
+        _seed_history(workspace="https://ws.example")
+
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        fake_cfg.project_name = "demo"
+        fake_cfg.api_version = "x"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+        # Force the display batch size to be large enough that fill-up
+        # isn't the reason for the stop.
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.shutil.get_terminal_size",
+            lambda: MagicMock(lines=100),
+        )
+
+        first_page = self._make_page(
+            [
+                self._make_op("op-1"),
+                self._make_op("op-2"),
+                self._make_op("op-other"),
+            ],
+            next_link="https://api.example/next",
+        )
+
+        list_calls: list = []
+        page_calls: list = []
+
+        def fake_list_operations(*a, **kw):
+            list_calls.append((a, kw))
+            return first_page
+
+        def fake_list_operations_page(link):
+            page_calls.append(link)
+            return self._make_page(
+                [self._make_op("op-also-not-mine")], next_link=None
+            )
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.list_operations",
+            fake_list_operations,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.list_operations_page",
+            fake_list_operations_page,
+        )
+
+        result = runner.invoke(app, ["job", "list"])
+        assert result.exit_code == 0
+        # Both seeded mine-IDs in the workspace are on the first page,
+        # so list_operations_page should NEVER have been called.
+        assert len(list_calls) == 1
+        assert page_calls == [], (
+            f"Expected no follow-up pages but got {page_calls!r}"
+        )
+
+    def test_stops_when_op_predates_oldest_mine_submission(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The single mine-id isn't on the first page, but the page
+        crosses into ops older than our oldest local submission;
+        the paginator should stop without fetching more."""
+        # History: a single recent submission; the cutoff will be ~1h
+        # before this timestamp.
+        job_history.record_submission(
+            "needle-op",
+            workspace_url="https://ws.example",
+            project_name="proj-1",
+            submitted_at=(
+                datetime.now(tz=timezone.utc) - timedelta(seconds=30)
+            ).isoformat().replace("+00:00", "Z"),
+        )
+
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        fake_cfg.project_name = "demo"
+        fake_cfg.api_version = "x"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.shutil.get_terminal_size",
+            lambda: MagicMock(lines=100),
+        )
+
+        # First page: 3 ops, all far older (~2 days) than the local
+        # submission cutoff. None match by ID either.
+        old_ops = [
+            self._make_op(f"unrelated-{i}", age_seconds=2 * 86400)
+            for i in range(3)
+        ]
+        first_page = self._make_page(old_ops, next_link="https://api.example/next")
+
+        list_calls: list = []
+        page_calls: list = []
+
+        def fake_list_operations(*a, **kw):
+            list_calls.append((a, kw))
+            return first_page
+
+        def fake_list_operations_page(link):
+            page_calls.append(link)
+            return self._make_page([], next_link=None)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.list_operations",
+            fake_list_operations,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.list_operations_page",
+            fake_list_operations_page,
+        )
+
+        result = runner.invoke(app, ["job", "list"])
+        assert result.exit_code == 0
+        # First op already predates the cutoff (~1h ago, ops are ~2d old),
+        # so the not_before guard should fire on op #1 — no follow-up
+        # pages and only one op actually scanned.
+        assert len(list_calls) == 1
+        assert page_calls == []
 
 
 class TestRecorderIntegration:

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -1,0 +1,333 @@
+"""Tests for ``discovery job history`` and ``--mine`` filter integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from discovery.common import job_history
+from discovery.poll import cli_submit
+from discovery.poll.cli import app
+from discovery.poll.models.tool_response import AzureCoreOperationState
+
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_history(workspace: str = "https://ws.example") -> None:
+    job_history.record_submission(
+        "op-1",
+        command="echo first",
+        workspace_url=workspace,
+        project_name="proj-1",
+        mode="start",
+        submitted_at="2026-05-31T10:00:00Z",
+        hostname="laptop-a",
+    )
+    job_history.record_submission(
+        "op-2",
+        command="echo second",
+        workspace_url=workspace,
+        project_name="proj-1",
+        mode="batch",
+        submitted_at="2026-06-01T10:00:00Z",
+        hostname="laptop-a",
+    )
+    job_history.record_submission(
+        "op-3",
+        command="echo third",
+        workspace_url="https://other.example",
+        project_name="proj-1",
+        mode="start",
+        submitted_at="2026-06-01T11:00:00Z",
+        hostname="laptop-a",
+    )
+
+
+# ---------------------------------------------------------------------------
+# `discovery job history`
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryCommand:
+    def test_path_prints_location(self) -> None:
+        result = runner.invoke(app, ["job", "history", "--path"])
+        assert result.exit_code == 0
+        # The autouse conftest fixture isolates the home dir, so the
+        # printed path should be under it.
+        assert "job-history.jsonl" in result.stdout
+
+    def test_empty_history_prints_friendly_message(self) -> None:
+        result = runner.invoke(
+            app, ["job", "history", "--all-workspaces"]
+        )
+        assert result.exit_code == 0
+        assert "No local job-history entries" in result.stdout
+
+    def test_lists_entries_newest_first(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_history()
+        # --all-workspaces avoids triggering load_project_config (which
+        # needs a real config file).
+        result = runner.invoke(
+            app, ["job", "history", "--all-workspaces"]
+        )
+        assert result.exit_code == 0
+        # All three op IDs visible
+        for op in ("op-1", "op-2", "op-3"):
+            assert op in result.stdout
+        # Newest first: op-3 should appear before op-1
+        assert result.stdout.index("op-3") < result.stdout.index("op-1")
+
+    def test_limit_truncates_results(self) -> None:
+        _seed_history()
+        result = runner.invoke(
+            app,
+            ["job", "history", "--all-workspaces", "--limit", "1"],
+        )
+        assert result.exit_code == 0
+        # Only the newest entry (op-3) should be in the table.
+        assert "op-3" in result.stdout
+        assert "op-1" not in result.stdout
+        assert "op-2" not in result.stdout
+
+    def test_since_filter_shorthand(self) -> None:
+        _seed_history()
+        # 30d back from now (2026) is still well after May 2026 entries,
+        # so '30000d' is a safer "include everything" sentinel.
+        # We instead verify the filter works by using a future cutoff
+        # that excludes everything.
+        far_future = (datetime.now(tz=timezone.utc) + timedelta(days=1)).strftime(
+            "%Y-%m-%d"
+        )
+        result = runner.invoke(
+            app,
+            ["job", "history", "--all-workspaces", "--since", far_future],
+        )
+        assert result.exit_code == 0
+        assert "No local job-history entries" in result.stdout
+
+    def test_workspace_scoping_is_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_history()
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_history.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        result = runner.invoke(app, ["job", "history"])
+        assert result.exit_code == 0
+        assert "op-1" in result.stdout
+        assert "op-2" in result.stdout
+        # op-3 is on a different workspace — filtered out by default.
+        assert "op-3" not in result.stdout
+
+    def test_clear_requires_confirmation(self) -> None:
+        _seed_history()
+        # Decline confirmation; file should be untouched.
+        result = runner.invoke(app, ["job", "history", "--clear"], input="n\n")
+        assert result.exit_code == 0
+        entries = job_history.load_history()
+        assert len(entries) == 3
+
+    def test_clear_with_confirmation_wipes_file(self) -> None:
+        _seed_history()
+        result = runner.invoke(app, ["job", "history", "--clear"], input="y\n")
+        assert result.exit_code == 0
+        assert not job_history.history_path().exists()
+
+
+# ---------------------------------------------------------------------------
+# --mine filter on `discovery job list`
+# ---------------------------------------------------------------------------
+
+
+class TestMineFilter:
+    def test_mine_exits_friendly_when_history_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+        result = runner.invoke(app, ["job", "running", "--mine"])
+        assert result.exit_code == 0
+        assert "No locally-recorded jobs" in result.stdout
+
+    def test_list_mine_invokes_paginator_with_mine_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Seed history for the configured workspace.
+        _seed_history(workspace="https://ws.example")
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        fake_cfg.nodepools = []
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+
+        captured = {}
+
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+            captured["filter_fn"] = filter_fn
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status._paginated_list", fake_paginated
+        )
+        result = runner.invoke(app, ["job", "list", "--mine"])
+        assert result.exit_code == 0
+
+        fn = captured["filter_fn"]
+        # op-1 and op-2 are in history; op-3 (other workspace) is not.
+        op_known = MagicMock(
+            id="op-1",
+            created_by="someone",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        op_unknown = MagicMock(
+            id="op-3",
+            created_by="someone",
+            nodepool_id="x",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        assert fn(op_known) is True
+        assert fn(op_unknown) is False
+
+    def test_running_mine_invokes_paginator_with_mine_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _seed_history(workspace="https://ws.example")
+        fake_cfg = MagicMock()
+        fake_cfg.workspace_url = "https://ws.example"
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.load_project_config",
+            lambda *_a, **_k: fake_cfg,
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.get_config_file_path",
+            lambda: Path("/tmp/ignored"),
+        )
+        monkeypatch.setattr(
+            "discovery.poll.cli_status.emit_env", lambda *_a, **_k: None
+        )
+
+        captured = {}
+
+        async def fake_paginated(*, env_cfg, filter_fn, limit=0, page_size=0):
+            captured["filter_fn"] = filter_fn
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_status._paginated_list", fake_paginated
+        )
+        # ``--all`` disables the per-user filter so the only thing the
+        # filter_fn ends up applying is the mine_ids set we care about.
+        result = runner.invoke(app, ["job", "running", "--mine", "--all"])
+        assert result.exit_code == 0
+
+        fn = captured["filter_fn"]
+        op = MagicMock(
+            id="op-1",
+            created_by="me",
+            status=AzureCoreOperationState.RUNNING,
+        )
+        assert fn(op) is True
+        op_other = MagicMock(
+            id="not-in-history",
+            created_by="me",
+            status=AzureCoreOperationState.RUNNING,
+        )
+        assert fn(op_other) is False
+
+
+# ---------------------------------------------------------------------------
+# Submit-site integration
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderIntegration:
+    """Verify the recorder helper writes a usable record on a fake submit."""
+
+    def test_record_job_submission_writes_entry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_cfg = MagicMock()
+        env_cfg.tool_id = "tool/xyz"
+        env_cfg.project_name = "demo"
+        env_cfg.workspace_url = "https://ws.example"
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.sys.argv",
+            ["discovery", "job", "start", "echo hi"],
+        )
+        cli_submit._record_job_submission(
+            "fresh-op-id",
+            env_cfg,
+            command="echo hi",
+            nodepool_id="np/123",
+            mode=job_history.MODE_START,
+        )
+        entries = job_history.load_history()
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.operation_id == "fresh-op-id"
+        assert e.command == "echo hi"
+        assert e.tool_id == "tool/xyz"
+        assert e.project_name == "demo"
+        assert e.workspace_url == "https://ws.example"
+        assert e.nodepool_id == "np/123"
+        assert e.mode == job_history.MODE_START
+        assert e.cli_argv == ["discovery", "job", "start", "echo hi"]
+
+    def test_record_swallows_exceptions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crashing record_submission must not propagate."""
+        def boom(*_a, **_kw):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "discovery.poll.cli_submit.record_submission", boom
+        )
+        cli_submit._record_job_submission(
+            "op-x",
+            MagicMock(tool_id="t", project_name="p", workspace_url="w"),
+            command="x",
+            nodepool_id="np",
+            mode=job_history.MODE_START,
+        )
+        # If we got here, no exception escaped.

--- a/utilities/supercomputer-cli/discovery/tests/test_job_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_job_history.py
@@ -304,3 +304,50 @@ class TestIsDisabled:
     ) -> None:
         monkeypatch.setenv(job_history.ENV_OPT_OUT, "0")
         assert job_history.is_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# parse_since (used by --since shorthand on history and cancel)
+# ---------------------------------------------------------------------------
+
+
+class TestParseSince:
+    def test_supports_seconds(self) -> None:
+        result = job_history.parse_since("30s")
+        # Should be ~30 seconds in the past, within a generous tolerance
+        # to absorb test-runner latency.
+        delta = (datetime.now(tz=timezone.utc) - result).total_seconds()
+        assert 25 <= delta <= 60
+
+    def test_supports_minutes(self) -> None:
+        result = job_history.parse_since("10m")
+        delta = (datetime.now(tz=timezone.utc) - result).total_seconds()
+        # 10 minutes = 600s; allow ±60s slack
+        assert 540 <= delta <= 660
+
+    def test_supports_hours(self) -> None:
+        result = job_history.parse_since("24h")
+        delta = (datetime.now(tz=timezone.utc) - result).total_seconds()
+        # 24h = 86400s; allow ±300s
+        assert 86100 <= delta <= 86700
+
+    def test_supports_days_and_weeks(self) -> None:
+        a = job_history.parse_since("7d")
+        b = job_history.parse_since("1w")
+        # 7d and 1w are identical
+        assert abs((a - b).total_seconds()) < 5
+
+    def test_absolute_date(self) -> None:
+        result = job_history.parse_since("2026-01-15")
+        assert result.year == 2026
+        assert result.month == 1
+        assert result.day == 15
+        assert result.tzinfo is not None
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "   ", "10x", "abc", "10", "min", "2026-13-99"],
+    )
+    def test_raises_on_empty_or_garbage(self, bad: str) -> None:
+        with pytest.raises(ValueError, match=r"(Invalid|empty)"):
+            job_history.parse_since(bad)

--- a/utilities/supercomputer-cli/discovery/tests/test_job_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_job_history.py
@@ -1,0 +1,306 @@
+"""Tests for :mod:`discovery.common.job_history`."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from discovery.common import job_history
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    lines = [
+        line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    return [json.loads(line) for line in lines]
+
+
+# ---------------------------------------------------------------------------
+# record_submission
+# ---------------------------------------------------------------------------
+
+
+class TestRecordSubmission:
+    def test_appends_entry_with_all_fields(self) -> None:
+        entry = job_history.record_submission(
+            "op-1",
+            command="echo hello",
+            tool_id="tool/123",
+            nodepool_id="np/abc",
+            project_name="proj-x",
+            workspace_url="https://ws.example",
+            mode=job_history.MODE_START,
+            cli_argv=["discovery", "job", "start", "echo hello"],
+            hostname="laptop-1",
+            submitted_at="2026-06-01T12:00:00Z",
+        )
+        assert entry is not None
+        assert entry.operation_id == "op-1"
+
+        records = _read_jsonl(job_history.history_path())
+        assert len(records) == 1
+        r = records[0]
+        assert r["operation_id"] == "op-1"
+        assert r["command"] == "echo hello"
+        assert r["tool_id"] == "tool/123"
+        assert r["nodepool_id"] == "np/abc"
+        assert r["project_name"] == "proj-x"
+        assert r["workspace_url"] == "https://ws.example"
+        assert r["mode"] == "start"
+        assert r["cli_argv"] == ["discovery", "job", "start", "echo hello"]
+        assert r["hostname"] == "laptop-1"
+        assert r["submitted_at"] == "2026-06-01T12:00:00Z"
+        assert r["schema_version"] == job_history.SCHEMA_VERSION
+
+    def test_returns_none_when_opted_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(job_history.ENV_OPT_OUT, "1")
+        entry = job_history.record_submission("op-1", command="x")
+        assert entry is None
+        assert not job_history.history_path().exists()
+
+    def test_skips_empty_operation_id(self) -> None:
+        assert job_history.record_submission("") is None
+        assert not job_history.history_path().exists()
+
+    def test_swallows_io_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(*_a, **_kw):
+            msg = "disk full"
+            raise OSError(msg)
+
+        monkeypatch.setattr(
+            "discovery.common.job_history.Path.open", boom
+        )
+        # Should not raise — recording is opportunistic.
+        result = job_history.record_submission("op-1", command="x")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrent submits (the batch case)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAppends:
+    def test_thread_safe_under_concurrent_writes(self) -> None:
+        """All records from N threads must land in the file intact."""
+        threads = []
+        n = 50
+        for i in range(n):
+            t = threading.Thread(
+                target=job_history.record_submission,
+                args=(f"op-{i}",),
+                kwargs={"command": f"cmd {i}", "mode": job_history.MODE_BATCH},
+            )
+            threads.append(t)
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        records = _read_jsonl(job_history.history_path())
+        assert len(records) == n
+        # Every operation_id must be present exactly once and the lines
+        # must be parseable (no torn writes).
+        ids = {r["operation_id"] for r in records}
+        assert ids == {f"op-{i}" for i in range(n)}
+
+
+# ---------------------------------------------------------------------------
+# load_history filtering
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHistory:
+    @pytest.fixture
+    def _seeded(self) -> None:
+        job_history.record_submission(
+            "op-a",
+            workspace_url="ws-1",
+            project_name="proj-1",
+            hostname="host-a",
+            submitted_at="2026-05-01T00:00:00Z",
+        )
+        job_history.record_submission(
+            "op-b",
+            workspace_url="ws-1",
+            project_name="proj-2",
+            hostname="host-a",
+            submitted_at="2026-05-15T00:00:00Z",
+        )
+        job_history.record_submission(
+            "op-c",
+            workspace_url="ws-2",
+            project_name="proj-1",
+            hostname="host-b",
+            submitted_at="2026-06-01T00:00:00Z",
+        )
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_loads_all_when_unfiltered(self) -> None:
+        entries = job_history.load_history()
+        assert {e.operation_id for e in entries} == {"op-a", "op-b", "op-c"}
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_filters_by_workspace(self) -> None:
+        entries = job_history.load_history(workspace_url="ws-1")
+        assert {e.operation_id for e in entries} == {"op-a", "op-b"}
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_filters_by_project(self) -> None:
+        entries = job_history.load_history(project_name="proj-1")
+        assert {e.operation_id for e in entries} == {"op-a", "op-c"}
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_filters_by_hostname(self) -> None:
+        entries = job_history.load_history(hostname="host-b")
+        assert {e.operation_id for e in entries} == {"op-c"}
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_filters_by_since(self) -> None:
+        since = datetime(2026, 5, 10, tzinfo=timezone.utc)
+        entries = job_history.load_history(since=since)
+        assert {e.operation_id for e in entries} == {"op-b", "op-c"}
+
+    @pytest.mark.usefixtures("_seeded")
+    def test_combined_filters(self) -> None:
+        entries = job_history.load_history(
+            workspace_url="ws-1", project_name="proj-2"
+        )
+        assert {e.operation_id for e in entries} == {"op-b"}
+
+    def test_returns_empty_when_no_file(self) -> None:
+        assert job_history.load_history() == []
+
+    def test_skips_corrupt_lines(self) -> None:
+        path = job_history.history_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "{not json}\n"
+            + json.dumps({"operation_id": "op-1", "submitted_at": "2026-01-01T00:00:00Z"})
+            + "\n"
+            + json.dumps({"no_id": True})
+            + "\n",
+            encoding="utf-8",
+        )
+        entries = job_history.load_history()
+        assert len(entries) == 1
+        assert entries[0].operation_id == "op-1"
+
+    def test_ignores_unknown_keys_in_records(self) -> None:
+        path = job_history.history_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "operation_id": "op-1",
+                "submitted_at": "2026-01-01T00:00:00Z",
+                "future_field_we_dont_know_about": 42,
+            })
+            + "\n",
+            encoding="utf-8",
+        )
+        entries = job_history.load_history()
+        assert len(entries) == 1
+        assert entries[0].operation_id == "op-1"
+
+
+# ---------------------------------------------------------------------------
+# local_operation_ids
+# ---------------------------------------------------------------------------
+
+
+class TestLocalOperationIds:
+    def test_returns_set_of_ids(self) -> None:
+        job_history.record_submission("op-1", workspace_url="w")
+        job_history.record_submission("op-2", workspace_url="w")
+        assert job_history.local_operation_ids(workspace_url="w") == {
+            "op-1",
+            "op-2",
+        }
+
+    def test_scoped_by_workspace(self) -> None:
+        job_history.record_submission("op-1", workspace_url="w1")
+        job_history.record_submission("op-2", workspace_url="w2")
+        assert job_history.local_operation_ids(workspace_url="w1") == {"op-1"}
+
+
+# ---------------------------------------------------------------------------
+# prune + clear
+# ---------------------------------------------------------------------------
+
+
+class TestPruneAndClear:
+    def test_prune_by_count(self) -> None:
+        for i in range(5):
+            job_history.record_submission(
+                f"op-{i}", submitted_at=f"2026-05-0{i+1}T00:00:00Z"
+            )
+        removed = job_history.prune(keep_count=2)
+        assert removed == 3
+        remaining = {e.operation_id for e in job_history.load_history()}
+        # Newest two retained (load_history preserves write order).
+        assert remaining == {"op-3", "op-4"}
+
+    def test_prune_by_since(self) -> None:
+        job_history.record_submission(
+            "old", submitted_at="2025-01-01T00:00:00Z"
+        )
+        job_history.record_submission(
+            "new", submitted_at="2026-06-01T00:00:00Z"
+        )
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        removed = job_history.prune(keep_since=since)
+        assert removed == 1
+        remaining = {e.operation_id for e in job_history.load_history()}
+        assert remaining == {"new"}
+
+    def test_prune_noop_when_nothing_to_remove(self) -> None:
+        job_history.record_submission("op-1")
+        assert job_history.prune(keep_count=10) == 0
+
+    def test_clear_deletes_file_and_returns_count(self) -> None:
+        for i in range(3):
+            job_history.record_submission(f"op-{i}")
+        assert job_history.clear() == 3
+        assert not job_history.history_path().exists()
+
+    def test_clear_on_missing_file_returns_zero(self) -> None:
+        assert job_history.clear() == 0
+
+
+# ---------------------------------------------------------------------------
+# is_disabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsDisabled:
+    def test_default_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(job_history.ENV_OPT_OUT, raising=False)
+        assert job_history.is_disabled() is False
+
+    def test_recognizes_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for v in ("1", "true", "yes", "on", "TRUE"):
+            monkeypatch.setenv(job_history.ENV_OPT_OUT, v)
+            assert job_history.is_disabled() is True
+
+    def test_ignores_other_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(job_history.ENV_OPT_OUT, "0")
+        assert job_history.is_disabled() is False


### PR DESCRIPTION
## Summary

Adds a per-machine job-submit history so users can quickly find their own jobs and review what they submitted previously even after the service-side list has rolled over.

* Every `discovery job start` / `batch` / `vscode` appends a record to `~/.discovery/job-history.jsonl`.
* New `discovery job history` command browses the local store (no API call).
* New `--mine` flag on `discovery job list / running / pending / done` restricts the *server-side* listing to operations submitted from this machine.

```
$ discovery job history --limit 3
┏━━━━━━━━━━━━━━┳───────────┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Operation ID ┃ Submitted ┃ Mode   ┃ Project┃ Host         ┃ Command           ┃
┡━━━━━━━━━━━━━━╇───────────╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ op-cccc3333  │ 5m ago    │ start  │ demo   │ laptop-1     │ echo hello        │
│ op-bbbb2222  │ 7h ago    │ batch  │ demo   │ laptop-1     │ python train.py … │
│ op-aaaa1111  │ 2d ago    │ start  │ demo   │ laptop-1     │ echo first        │
└──────────────┴───────────┴────────┴────────┴──────────────┴───────────────────┘

$ discovery job list --mine
…only jobs you submitted from this machine for the current workspace…
```

## Design

### Storage (`discovery.common.job_history`)
- **JSON-Lines** file at `~/.discovery/job-history.jsonl` — append-only, easy to `cat`/`jq`, no DB dependency, naturally chronological.
- **Forward-compatible**: unknown keys are ignored by the loader so we can add fields without breaking older releases that read the file. Records carry a `schema_version`.
- **Thread-safe append**: `discovery job batch` submits in parallel through a `ThreadPoolExecutor`; an in-process `threading.Lock` serializes writes so records can't tear. Verified with a 50-thread concurrency test.
- **Scoping** built into `load_history()`: `workspace_url` / `project_name` / `hostname` / `since` filters keep multi-environment users' history clean. The default `discovery job history` view scopes to the current workspace; `--all-workspaces` shows everything.
- **Opt-out** via `DISCOVERY_NO_JOB_HISTORY=1` (one-shot) or `discovery job history --clear` (persistent wipe).
- **Opportunistic**: I/O errors are logged at DEBUG and never break the submit — recording is best-effort.

### Recorder hook (`discovery.poll.cli_submit`)
- `start` is refactored to call `start_tool_run` + record + `poll_operation` directly (mirrors what `run_and_poll` does internally). This lets us record *between* submit and poll — even Ctrl+C during polling leaves a usable history entry.
- `batch` records inside the worker function so each parallel submission lands in history with its own operation ID.
- `vscode` records with a synthetic `<vscode tunnel: NAME>` command label.

### `discovery job history` command
| Flag | Effect |
| --- | --- |
| `--limit / -n` | Show the most recent N entries (default 50). |
| `--since {YYYY-MM-DD|24h|7d|2w}` | Date or shorthand offset filter. |
| `--workspace / --all-workspaces` | Default: only show entries for the current workspace. |
| `--this-host` | Restrict to entries recorded on this machine. |
| `--path` | Print the history file path and exit. |
| `--clear` | Wipe the entire history file (interactive confirm). |

### `--mine` filter
Added to `discovery job list`, `running`, `pending`, and `done`. The existing server-side listing is intersected with `local_operation_ids(workspace_url=…)`. When the local history is empty for the current workspace, the command exits with a friendly hint rather than silently returning nothing.

### `discovery doctor`
New section reports whether history recording is enabled, the file path, and the entry count.

## Tests

37 new test cases in `tests/test_job_history.py` and `tests/test_cli_history.py`:

- Cache I/O round-trip with all fields preserved
- Forward-compatibility: unknown fields ignored, corrupt lines skipped
- Opt-out via env var
- `record_submission` swallows OSError without raising
- 50-thread concurrent-write smoke (no torn records, all 50 IDs present)
- All `load_history` filters (workspace, project, hostname, since, combined)
- `prune(keep_count=…)`, `prune(keep_since=…)`, `clear()`
- `discovery job history` `--path`, `--limit`, `--since`, `--clear` (with and without confirmation), default workspace scoping
- `--mine` filter on both `list` (predicate path) and `running` (status-helper path), including the empty-history "friendly exit" behavior
- Submit-site integration: `_record_job_submission` writes a complete entry and never propagates exceptions

Existing `test_start_with_mocked_deps` updated to patch `start_tool_run` + `poll_operation` instead of the removed `run_and_poll` patch (which was only valid in `cli_submit.start`; `run_and_poll` is still used elsewhere in the codebase).

**Results**: 395 / 395 pass (excluding 10 pre-existing failures from a missing `tests/artifacts/response.json` fixture, unrelated to this change). `ruff check` on the changed-file set has 2 *fewer* warnings than `origin/main`. `mypy --exclude .venv` shows the same error count as baseline on `cli_submit.py` and `cli_status.py` — no new type errors.

## Out of scope / future work

- **Cross-process file locking.** Two concurrent `discovery` processes on the same machine could in theory interleave large writes. In practice each line is well under the kernel's atomic `O_APPEND` threshold for normal records on Linux/macOS/WSL. A `fcntl.flock` could be added later if needed.
- **Outcome enrichment.** Records are written at submit time only. A future enhancement could re-open the file and append a "completed_at"/"final_status" record (or rewrite the line) when a job finishes. Today users get final status by combining `--mine` with `discovery job status`.
- **Auto-prune.** History grows indefinitely (small: ~300 bytes/record). `discovery job history --clear` lets users reset; an auto-prune-after-N-days policy could be added later.
