### PR TITLE
Set batch output ordering to maintain input file ordering

### DIFF
--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -12,6 +12,7 @@ import httpx
 import typer
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from discovery.common.job_history import (
     MODE_BATCH,
@@ -902,8 +903,10 @@ def batch(
 
     # Submit jobs in parallel
     total = len(command_list)
-    operation_ids: list[str] = []
+    # Collect (index, operation_id, command) so we can print in input order
+    successful_jobs: list[tuple[int, str, str]] = []
     failed_jobs: list[tuple[int, str]] = []
+    completed_count = 0
 
     info(f"Submitting {total} operations using {max_workers} parallel workers...")
 
@@ -916,16 +919,32 @@ def batch(
         # Collect results as they complete
         for future in as_completed(futures):
             idx, op_id, err = future.result()
+            completed_count += 1
             if op_id:
-                operation_ids.append(op_id)
-                info(f"  [{len(operation_ids)}/{total}] Operation ID: {op_id}")
+                cmd_preview = command_list[idx][:80]
+                successful_jobs.append((idx, op_id, command_list[idx]))
+                info(f"  [{completed_count}/{total}] {op_id}  {cmd_preview}")
             else:
                 failed_jobs.append((idx, err or "Unknown error"))
                 error(f"  [FAILED] Job {idx + 1}: {err}")
 
-    info(f"Batch complete. Submitted {len(operation_ids)} operations.")
+    info(f"Batch complete. Submitted {len(successful_jobs)} operations.")
     if failed_jobs:
         error(f"Failed to submit {len(failed_jobs)} jobs.")
+
+    # Print ordered mapping table so users can correlate operation IDs to commands
+    if successful_jobs:
+        successful_jobs.sort(key=lambda t: t[0])
+        table = Table(title="Operation Mapping (input order)")
+        table.add_column("#", justify="right", style="cyan")
+        table.add_column("Operation ID", style="green")
+        table.add_column("Command", style="white")
+        for idx, op_id, cmd in successful_jobs:
+            table.add_row(str(idx + 1), op_id, cmd[:80])
+        Console().print(table)
+
+    # Keep operation_ids list for any downstream callers
+    operation_ids: list[str] = [op_id for _, op_id, _ in successful_jobs]
 
 
 @app.command("vscode")

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
@@ -138,7 +138,7 @@ class TestBatchCommand:
         assert "SIZE" in result.output
 
     def test_batch_with_mocked_deps(self, tmp_path):
-        """Test batch with mocked dependencies."""
+        """Test batch with mocked dependencies and verify mapping table."""
         with patch.object(cli_submit, "load_project_config") as mock_proj:
             mock_cfg = MagicMock()
             mock_cfg.project_name = "test-project"
@@ -163,6 +163,57 @@ class TestBatchCommand:
                                     result = runner.invoke(app, ["job", "batch", "3", "echo test"])
 
         assert result.exit_code == 0
+        # Mapping table should appear with operation IDs
+        assert "Operation Mapping" in result.output
+        assert "op-123" in result.output
+
+    def test_batch_commands_file_preserves_order(self, tmp_path):
+        """Test that batch --commands-file prints mapping in input order."""
+        cmds_file = tmp_path / "cmds.txt"
+        cmds_file.write_text("echo molecule_A\necho molecule_B\necho molecule_C\n")
+
+        # Return distinct op IDs per call to verify ordering
+        call_count = 0
+
+        def _make_response(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.id = f"op-{call_count:03d}"
+            return resp
+
+        with patch.object(cli_submit, "load_project_config") as mock_proj:
+            mock_cfg = MagicMock()
+            mock_cfg.project_name = "test-project"
+            mock_cfg.workspace_url = "https://example.com"
+            mock_cfg.tool_id = "tool-123"
+            mock_cfg.nodepool_id = "nodepool-123"
+            mock_cfg.datacontainer_id = "dc-123"
+            mock_proj.return_value = mock_cfg
+
+            with patch.object(cli_submit, "load_tool_config"):
+                with patch.object(cli_submit, "ensure_datacontainer"):
+                    with patch.object(cli_submit, "emit_env"):
+                        with patch.object(
+                            cli_submit, "prepare_command", side_effect=lambda c, *a, **kw: c
+                        ):
+                            with patch.object(
+                                cli_submit, "get_azure_username", return_value="testuser"
+                            ):
+                                with patch.object(
+                                    cli_submit, "start_tool_run", side_effect=_make_response
+                                ):
+                                    result = runner.invoke(
+                                        app,
+                                        ["job", "batch", "--commands-file", str(cmds_file)],
+                                    )
+
+        assert result.exit_code == 0
+        assert "Operation Mapping" in result.output
+        # All three commands should appear in the mapping table
+        assert "molecule_A" in result.output
+        assert "molecule_B" in result.output
+        assert "molecule_C" in result.output
 
     def test_batch_size_validation(self):
         """Test that batch rejects size < 1."""


### PR DESCRIPTION
## Summary

Match output ordering to input ordering when using CLI to submit a batch of jobs.

## Type of change

- [ ] New agent (under `agents/<name>/`)
- [ ] Update to an existing agent
- [ ] New starter kit (under `starter-kits/<name>/`)
- [ ] Update to an existing starter kit
- [ ] Schema change (`docs/schemas/**`)
- [ ] Workflow / script change (`.github/**`)
- [ ] Documentation only
- [x] Other (describe below)

## Related issue / tracking

n/a

## Schema impact

- [x] No schema changes
- [ ] Schema changes are backward compatible
- [ ] Schema changes are **breaking** — add the `breaking-change` label and link the rollout plan below

## Validation checklist

- [x] Documentation (`README.md`, schemas) is updated to match the change.
- [x] No hand-edits to `.auto-registry/**` (it is generated post-merge).
- [x] No OS / editor artefacts committed (`.DS_Store`, `.env`, `*.swp`, `.idea/`, `.vs/`, etc.).
- [x] If model-weight files are added, they are Git-LFS tracked, ≤5 GB each, and in an allowed format.
- [x] No secrets, customer data, or internal-only URLs are committed.
- [x] All Markdown links resolve.