### PR TITLE
supercomputer-cli: add 2026-06-01 GA data-plane + ARM api-versions

### DIFF
--- a/utilities/supercomputer-cli/README.md
+++ b/utilities/supercomputer-cli/README.md
@@ -117,7 +117,7 @@ Set or change the API version (persisted to your config) with
 `--api-version`:
 
 ```bash
-discovery configure --api-version 2026-02-01-preview
+discovery configure --api-version 2026-06-01
 ```
 
 If you don't pass `--api-version`, the full `configure` flow prompts you to

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_build.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_build.py
@@ -329,10 +329,11 @@ def _ensure_storage_assets_and_containers(
     """Ensure storage assets and blob containers for given usernames exist.
 
     Storage assets are the v2 equivalent of data assets, introduced in the
-    ``2026-02-01-preview`` API version. For ``AzureStorageBlob``-backed
-    storage containers, this helper creates both a storage asset *and* a blob
-    container of the same name (mirroring the legacy data-asset flow), so
-    ``discovery://storageassets.../storageassets/{name}`` URIs resolve.
+    ``2026-02-01-preview`` API version and GA at ``2026-06-01``. For
+    ``AzureStorageBlob``-backed storage containers, this helper creates both
+    a storage asset *and* a blob container of the same name (mirroring the
+    legacy data-asset flow), so ``discovery://storageassets.../storageassets/{name}``
+    URIs resolve.
 
     Requires ``storagecontainer_id`` to be set in ``env_cfg``.
 

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_cleanup.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_cleanup.py
@@ -16,6 +16,10 @@ from rich.console import Console
 from rich.table import Table
 
 from discovery.common.logging import debug, error, info
+from discovery.poll.models.arm_versions import (
+    DATAASSET_ARM_API_VERSION,
+    DATACONTAINER_ARM_API_VERSION,
+)
 from discovery.poll.models.tool_response import AzureCoreOperationState
 from discovery.poll.models.tool_run import DataMount, ToolRunRequest
 
@@ -123,7 +127,7 @@ def _resource_exists(resource_id: str, subscription: str) -> bool:
             "az", "resource", "show",
             "--ids", resource_id,
             "--subscription", subscription,
-            "--api-version", "2025-07-01-preview",
+            "--api-version", DATACONTAINER_ARM_API_VERSION,
             "-o", "json",
         ])
         return True
@@ -137,7 +141,7 @@ def _get_resource(resource_id: str, subscription: str) -> dict:
         "az", "resource", "show",
         "--ids", resource_id,
         "--subscription", subscription,
-        "--api-version", "2025-07-01-preview",
+        "--api-version", DATACONTAINER_ARM_API_VERSION,
         "-o", "json",
     ])
 
@@ -176,7 +180,7 @@ def _ensure_anf_datacontainer(
         "--id", dc_id,
         "--subscription", subscription,
         "--location", location,
-        "--api-version", "2025-07-01-preview",
+        "--api-version", DATACONTAINER_ARM_API_VERSION,
         "--properties", json.dumps({
             "dataStore": {
                 "kind": "DiscoveryStorage",
@@ -207,7 +211,7 @@ def _ensure_anf_root_dataasset(subscription: str, resource_group: str, location:
         "--id", da_id,
         "--subscription", subscription,
         "--location", location,
-        "--api-version", "2025-07-01-preview",
+        "--api-version", DATAASSET_ARM_API_VERSION,
         "--properties", json.dumps({
             "description": "Root of ANF scratch volume for cleanup operations",
             "path": ".",

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_configure.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_configure.py
@@ -59,7 +59,7 @@ def configure(
     api_version: str = typer.Option(
         None,
         "--api-version",
-        help="API version to use for data plane calls (e.g. 2026-02-01-preview). Saved to config. Skips the interactive picker when provided.",
+        help="API version to use for data plane calls (e.g. 2026-06-01). Saved to config. Skips the interactive picker when provided.",
     ),
 ) -> None:
     """Interactively select related resources and tool, and optionally persist to env file.

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -445,7 +445,7 @@ def start(
     api_version: str = typer.Option(
         None,
         "--api-version",
-        help="Override API version (e.g. 2026-02-01-preview). Defaults to configured version.",
+        help="Override API version (e.g. 2026-06-01). Defaults to configured version.",
     ),
     scratch: bool = typer.Option(
         False,
@@ -675,7 +675,7 @@ def batch(
     api_version: str = typer.Option(
         None,
         "--api-version",
-        help="Override API version (e.g. 2026-02-01-preview). Defaults to configured version.",
+        help="Override API version (e.g. 2026-06-01). Defaults to configured version.",
     ),
     use_entire_node: bool = typer.Option(
         False,
@@ -924,7 +924,7 @@ def vscode_cmd(
     api_version: str = typer.Option(
         None,
         "--api-version",
-        help="Override API version (e.g. 2026-02-01-preview). Defaults to configured version.",
+        help="Override API version (e.g. 2026-06-01). Defaults to configured version.",
     ),
     scratch: bool = typer.Option(
         False,

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -22,13 +22,14 @@ from discovery.common.job_history import (
     parse_since,
     record_submission,
 )
-from discovery.common.logging import debug, error, info, pretty_debug
+from discovery.common.logging import debug, error, info, pretty_debug, warn
 from discovery.poll.models.api_version import ApiVersion
 from discovery.poll.models.tool_run import (
     DataMount,
     InfraOverrides,
     InfraOverridesFlat,
     ResourceSpec,
+    StorageMountProtocol,
     ToolRunRequest,
 )
 
@@ -47,6 +48,7 @@ from .cli_helpers import (
     render_error_with_details,
 )
 from .dataplane_api import (
+    CancelWaitTimeoutError,
     PollError,
     cancel_operation,
     get_operation_status,
@@ -95,6 +97,32 @@ _LEGACY_API_VERSIONS = frozenset(v.wire_value for v in ApiVersion if v.uses_stor
 _NESTED_INFRA_OVERRIDES_API_VERSIONS = frozenset(
     v.wire_value for v in ApiVersion if v.uses_nested_infra_overrides
 )
+
+
+def _parse_mount_protocol_or_exit(
+    value: str | None, av: ApiVersion,
+) -> StorageMountProtocol | None:
+    """Parse a ``--mount-protocol`` flag value, fast-failing with ``typer.Exit``.
+
+    * ``None`` / empty → returns ``None`` (omit field; server uses container default).
+    * Value present but ``av`` does not support ``mountProtocol`` → exit code 2.
+    * Unknown enum value → exit code 2.
+    * Recognised value (case-insensitive) → returns the :class:`StorageMountProtocol`
+      member with the canonical wire casing.
+    """
+    if value is None or value == "":
+        return None
+    if not av.supports_mount_protocol:
+        error(
+            f"--mount-protocol requires API version 2026-06-01 or later; "
+            f"configured/selected version is {av.value!r}."
+        )
+        raise typer.Exit(code=2)
+    try:
+        return StorageMountProtocol.parse(value)
+    except ValueError as exc:
+        error(str(exc))
+        raise typer.Exit(code=2) from exc
 
 
 def _resolve_scratch_wrapper_id(np_info, env_cfg, av: ApiVersion) -> str:
@@ -456,6 +484,17 @@ def start(
             "wrapper for this supercomputer."
         ),
     ),
+    mount_protocol: str = typer.Option(
+        None,
+        "--mount-protocol",
+        help=(
+            "Override mount protocol for the /blob_user and /blob_shared data "
+            "mounts. Values: 'NFS' or 'BlobfuseCaching' (case-insensitive). "
+            "Requires API version 2026-06-01 (GA) or later. The scratch mount "
+            "is unaffected — it always uses the storage container's default "
+            "protocol."
+        ),
+    ),
 ) -> None:
     """Start a tool run. Polls until terminal status unless --no-wait provided."""
     debug("start(): entering")
@@ -536,6 +575,9 @@ def start(
     # Legacy: uri + discovery://dataassets, storageId required.
     # Modern: storageUri + discovery://storageassets, no storageId.
     av = ApiVersion.parse(effective_api_version)
+    # Validate --mount-protocol before any subsequent work (network calls,
+    # scratch resolution, etc.) so bad flags fail fast.
+    mp = _parse_mount_protocol_or_exit(mount_protocol, av)
     _scratch_mount = _scratch_mount_or_exit(np_info, env_cfg, av, scratch)
     if av.uses_dataassets_uri:
         output_uri = f"discovery://dataassets{env_cfg.datacontainer_id}/dataassets/{effective_username}"
@@ -554,8 +596,8 @@ def start(
         )
     else:
         output_mounts = [
-            DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}"),
-            DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared"),
+            DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}", mountProtocol=mp),
+            DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared", mountProtocol=mp),
             *([_scratch_mount] if _scratch_mount else []),
         ]
         payload = ToolRunRequest(
@@ -690,6 +732,15 @@ def batch(
             "Requires 'discovery configure --scratch-select'."
         ),
     ),
+    mount_protocol: str = typer.Option(
+        None,
+        "--mount-protocol",
+        help=(
+            "Override mount protocol for the /blob_user and /blob_shared data "
+            "mounts on every submitted job. Values: 'NFS' or 'BlobfuseCaching' "
+            "(case-insensitive). Requires API version 2026-06-01 (GA) or later."
+        ),
+    ),
 ) -> None:
     """Submit multiple independent tool runs. Does not poll for output.
 
@@ -796,6 +847,8 @@ def batch(
     # Resolve effective API version: CLI flag overrides config
     effective_api_version = api_version or env_cfg.api_version or None
     av = ApiVersion.parse(effective_api_version)
+    # Validate --mount-protocol before scratch resolution + submission loop.
+    mp = _parse_mount_protocol_or_exit(mount_protocol, av)
     _scratch_mount = _scratch_mount_or_exit(np_info, env_cfg, av, scratch)
 
     # Build infra_overrides using the schema variant matching the target api-version.
@@ -823,8 +876,8 @@ def batch(
                 )
             else:
                 output_mounts = [
-                    DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}"),
-                    DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared"),
+                    DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}", mountProtocol=mp),
+                    DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared", mountProtocol=mp),
                     *([_scratch_mount] if _scratch_mount else []),
                 ]
                 payload = ToolRunRequest(
@@ -934,6 +987,15 @@ def vscode_cmd(
             "Requires 'discovery configure --scratch-select'."
         ),
     ),
+    mount_protocol: str = typer.Option(
+        None,
+        "--mount-protocol",
+        help=(
+            "Override mount protocol for the /blob_user and /blob_shared data "
+            "mounts in the tunnel session. Values: 'NFS' or 'BlobfuseCaching' "
+            "(case-insensitive). Requires API version 2026-06-01 (GA) or later."
+        ),
+    ),
 ) -> None:
     """Start a VS Code tunnel session. Submits job and polls for device-flow URL."""
     debug("vscode(): entering")
@@ -1024,6 +1086,8 @@ def vscode_cmd(
 
     # Build payload — branching on API version capability.
     av = ApiVersion.parse(effective_api_version)
+    # Validate --mount-protocol before scratch resolution + submission.
+    mp = _parse_mount_protocol_or_exit(mount_protocol, av)
     _scratch_mount = _scratch_mount_or_exit(np_info, env_cfg, av, scratch)
     if av.uses_dataassets_uri:
         output_uri = f"discovery://dataassets{env_cfg.datacontainer_id}/dataassets/{effective_username}"
@@ -1042,8 +1106,8 @@ def vscode_cmd(
         )
     else:
         output_mounts = [
-            DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}"),
-            DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared"),
+            DataMount(mountPath="/blob_user", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/{effective_username}", mountProtocol=mp),
+            DataMount(mountPath="/blob_shared", storageUri=f"discovery://storageassets{env_cfg.storagecontainer_id}/storageassets/shared", mountProtocol=mp),
             *([_scratch_mount] if _scratch_mount else []),
         ]
         payload = ToolRunRequest(
@@ -1142,7 +1206,8 @@ def cancel(
             "given window. Accepts shorthand like '10m', '1h', '24h', '7d' "
             "or an absolute YYYY-MM-DD date. Scoped to the current "
             "workspace_url so a typo doesn't reach into a different "
-            "Discovery environment."
+            "Discovery environment. Bulk-cancel does not wait for each "
+            "operation to settle (use single-op cancel to wait)."
         ),
     ),
     yes: bool = typer.Option(
@@ -1157,14 +1222,37 @@ def cancel(
         "-p",
         help="Parallel cancel workers when --since is set (default: 16).",
     ),
+    no_wait: bool = typer.Option(
+        False,
+        "--no-wait",
+        help=(
+            "Return immediately after the cancel POST is accepted, instead of "
+            "polling until the operation reaches a terminal state. Default is "
+            "to wait. Has no effect with --since (bulk-cancel is always no-wait)."
+        ),
+    ),
+    wait_timeout: int = typer.Option(
+        120,
+        "--wait-timeout",
+        help=(
+            "Maximum seconds to wait for the cancelled operation to reach a "
+            "terminal state. On timeout the CLI exits 0 with a warning — the "
+            "cancel POST was accepted, it just didn't settle in time."
+        ),
+    ),
 ) -> None:
     """Cancel a running operation, or bulk-cancel recent local submissions.
 
     Two modes:
 
     * ``discovery job cancel <operation-id>`` — cancel a single specific op.
+      By default, polls until the operation reaches a terminal state
+      (``Succeeded`` / ``Failed`` / ``Canceled``) so the exit signal reflects
+      that cancellation actually propagated. Pass ``--no-wait`` to exit
+      immediately after the cancel POST is acknowledged.
     * ``discovery job cancel --since 10m`` — cancel every locally-recorded
-      job submitted in the last 10 minutes (current workspace only).
+      job submitted in the last 10 minutes (current workspace only). Always
+      fire-and-forget (no per-op wait) for throughput.
     """
     debug("cancel(): entering")
 
@@ -1187,8 +1275,33 @@ def cancel(
 
     info(f"Cancel requested for operation id={operation_id}")
     try:
-        cancel_operation(env_cfg.project_name, operation_id, env_cfg.workspace_url, api_version=env_cfg.api_version)
+        cancel_operation(
+            env_cfg.project_name,
+            operation_id,
+            env_cfg.workspace_url,
+            api_version=env_cfg.api_version,
+            wait=not no_wait,
+            wait_timeout_seconds=wait_timeout,
+        )
+    except CancelWaitTimeoutError as exc:
+        # Cancel POST was accepted server-side; we just didn't observe a terminal
+        # state within the budget. Treat as a soft success: exit 0 with a clear
+        # message so scripts don't pointlessly retry the cancel.
+        warn(str(exc))
+        warn(
+            f"Run `discovery job status {operation_id}` to check the current state."
+        )
+        return
     except httpx.HTTPStatusError as exc:
+        # 404 / 409 on the cancel POST itself means the op is already terminal —
+        # the user's goal ("make it stop") is satisfied. Mirrors the leniency
+        # _cancel_one_op applies in the bulk path.
+        if exc.response.status_code in (404, 409):
+            info(
+                f"Operation {operation_id} is already in a terminal state "
+                f"(HTTP {exc.response.status_code}); nothing to cancel."
+            )
+            return
         error(format_service_error(exc))
         raise typer.Exit(code=1) from exc
     except httpx.TransportError as exc:
@@ -1301,6 +1414,11 @@ def _cancel_one_op(env_cfg, op_id: str) -> tuple[str, str | None]:
 
     404/409 responses are treated as success — the op is already in a
     terminal state, so the user's goal ("make it stop") is already true.
+
+    Always uses ``wait=False`` because the bulk-cancel path optimises for
+    throughput; per-op polling would multiply the wall-clock time by the
+    cancel-settle latency. Single-op cancel (``discovery job cancel <id>``)
+    is where wait-by-default lives.
     """
     try:
         cancel_operation(
@@ -1308,6 +1426,7 @@ def _cancel_one_op(env_cfg, op_id: str) -> tuple[str, str | None]:
             op_id,
             env_cfg.workspace_url,
             api_version=env_cfg.api_version,
+            wait=False,
         )
     except httpx.HTTPStatusError as exc:
         status = exc.response.status_code

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
@@ -294,6 +294,29 @@ class TransientHTTPError(PollError):
     """Represents a transient HTTP/network issue suitable for retry."""
 
 
+class CancelWaitTimeoutError(PollError):
+    """Raised when ``cancel_operation(wait=True)`` accepted the cancel POST but the
+    operation did not reach a terminal state (``Succeeded``/``Failed``/``Canceled``)
+    within the configured wait window.
+
+    Distinguishes "cancel POST itself failed" (other ``PollError`` / HTTP errors)
+    from "cancel was queued but didn't settle in time". CLI callers can catch this
+    and exit successfully with a warning rather than treating it as a hard failure.
+    """
+
+
+# Positive allow-list of terminal operation states (per the GA 2026-06-01 swagger
+# `Azure.Core.Foundations.OperationState` enum and `AzureCoreOperationStateExtensions.IsTerminal()`).
+# Used by the cancel-wait path so a transient state surfaces as "still polling"
+# rather than mis-terminating like the legacy non-running heuristic would.
+_TERMINAL_OPERATION_STATES: frozenset[str] = frozenset({"Succeeded", "Failed", "Canceled"})
+
+# Polling cadence for the cancel-wait loop. Tighter than DEFAULT_POLL_INTERVAL=5
+# because cancellations typically settle within a few seconds — there's no tool
+# log progress to stream so the only cost of polling faster is the request rate.
+_CANCEL_WAIT_POLL_INTERVAL = 2
+
+
 _token_cache: dict[str, tuple[float, str]] = {}
 _TOKEN_REFRESH_MARGIN = 120  # refresh 2 min before actual expiry
 
@@ -484,16 +507,88 @@ def run_and_poll(
     )
 
 
+def _wait_for_cancel_terminal(
+    project_name: str,
+    operation_id: str,
+    workspace_url: str,
+    *,
+    api_version: str,
+    timeout_seconds: int,
+) -> str:
+    """Poll ``get_operation_status`` until the operation reaches a terminal state.
+
+    Uses the positive allow-list ``_TERMINAL_OPERATION_STATES`` (Succeeded / Failed /
+    Canceled). A 404 from the status endpoint during the wait is treated as terminal
+    success — the op was reaped, which means the user's cancellation goal ("make it
+    stop") is satisfied.
+
+    Returns the final status string. Raises :class:`CancelWaitTimeoutError` if the loop
+    exceeds ``timeout_seconds`` without reaching a terminal state.
+    """
+    start = time.time()
+    while True:
+        if time.time() - start > timeout_seconds:
+            msg = (
+                f"Cancel was accepted for operation {operation_id} but it did not "
+                f"reach a terminal state within {timeout_seconds}s"
+            )
+            raise CancelWaitTimeoutError(msg)
+        try:
+            data = get_operation_status(
+                project_name, operation_id, workspace_url, api_version=api_version,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                # Operation was reaped — cancel goal is satisfied.
+                debug(f"cancel wait: operation {operation_id} returned 404; treating as Canceled")
+                return "Canceled"
+            raise
+        if data.status in _TERMINAL_OPERATION_STATES:
+            return data.status
+        debug(f"cancel wait: operation {operation_id} status={data.status}; continuing to poll")
+        time.sleep(_CANCEL_WAIT_POLL_INTERVAL)
+
+
 def cancel_operation(
     project_name: str,
     operation_id: str,
     workspace_url: str,
     api_version: str,
-) -> None:
+    *,
+    wait: bool = False,
+    wait_timeout_seconds: int = 120,
+) -> str | None:
     """Request cancellation of a running operation.
 
-    Posts to the Tools cancel endpoint. Returns parsed JSON body if present,
-    otherwise an empty dict. Raises PollError for non-2xx responses or token issues.
+    Posts to the Tools cancel endpoint. On api-version ``>= 2026-06-01`` the server
+    returns a 202 Accepted with an LRO body and ``Operation-Location`` header; on
+    earlier versions the body is empty. Either way the operation continues toward a
+    terminal state asynchronously.
+
+    Args:
+        project_name: The Discovery project name.
+        operation_id: The operation id to cancel.
+        workspace_url: The workspace base URL.
+        api_version: The api-version query string.
+        wait: When True, after the POST is accepted, poll the operation until it
+            reaches a terminal state (``Succeeded`` / ``Failed`` / ``Canceled``).
+            Default ``False`` to preserve library back-compat for SDK callers; the
+            CLI explicitly passes ``wait=True``.
+        wait_timeout_seconds: Cap on the poll loop when ``wait=True``. On timeout
+            the cancel POST has already been accepted server-side; a
+            :class:`CancelWaitTimeoutError` is raised so callers can decide whether to
+            treat it as a hard failure.
+
+    Returns:
+        When ``wait=True``: the terminal status string from the final status poll.
+        When ``wait=False``: ``None`` (the function returns immediately after the
+        POST is acknowledged).
+
+    Raises:
+        PollError: missing required arguments.
+        CancelWaitTimeoutError: cancel POST was accepted but no terminal state observed
+            within ``wait_timeout_seconds`` (only when ``wait=True``).
+        httpx.HTTPStatusError: non-2xx response from the cancel POST itself.
     """
     if not project_name or not operation_id:
         msg = "project_name and operation_id required"
@@ -517,6 +612,20 @@ def cancel_operation(
         data=_EmptyBody(),
         params=params,
     )
+
+    if not wait:
+        return None
+
+    info(f"Waiting for cancellation of operation {operation_id} to settle…")
+    final_status = _wait_for_cancel_terminal(
+        project_name,
+        operation_id,
+        workspace_url,
+        api_version=api_version,
+        timeout_seconds=wait_timeout_seconds,
+    )
+    info(f"Operation {operation_id} reached terminal state: {final_status}")
+    return final_status
 
 
 def list_operations(
@@ -637,6 +746,7 @@ def get_compute_status(
 
 
 __all__ = [
+    "CancelWaitTimeoutError",
     "JsonValidationError",
     "PollError",
     "cancel_operation",

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/deploy_storageasset.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/deploy_storageasset.py
@@ -5,8 +5,10 @@ This module provides functions to:
 2. Deploy a storage asset if not present
 
 Storage assets are the v2 equivalent of data assets, introduced in the
-``2026-02-01-preview`` API version. They live under
-``Microsoft.Discovery/storagecontainers/{name}/storageAssets/{asset}``.
+``2026-02-01-preview`` API version and GA at ``2026-06-01``. They live under
+``Microsoft.Discovery/storagecontainers/{name}/storageAssets/{asset}``. The
+ARM api-version used for every ``az`` call here is pinned via
+:data:`discovery.poll.models.arm_versions.STORAGEASSET_ARM_API_VERSION`.
 
 Follows the same pattern as deploy_dataasset.py for consistency.
 """
@@ -25,12 +27,15 @@ import typer
 
 from discovery.common.logging import debug, error, info
 
+from .models.arm_versions import STORAGEASSET_ARM_API_VERSION
 from .models.dataasset import StorageAssetInputs
 
 
 TEMPLATE_DIR = files("discovery.poll").joinpath("templates/storageasset")
 
-STORAGE_ASSET_API_VERSION = "2026-02-01-preview"
+# Re-export under the historical name so any in-tree imports keep working.
+# New code should import from ``models.arm_versions`` directly.
+STORAGE_ASSET_API_VERSION = STORAGEASSET_ARM_API_VERSION
 
 
 def _load_text(name: str) -> str:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/api_version.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/api_version.py
@@ -13,9 +13,15 @@ The boundaries encoded here mirror the server contracts in the upstream service
     2025-07-01-preview     ``uri`` → dataassets       required     nested (resources/poolSize/imageUri)
     2025-12-01-preview     ``uri`` → dataassets       required     flat (cpu/ram/gpu/replicaCount/imageUri)
     2026-02-01-preview     ``storageUri`` → storageassets  omitted      flat (+ maxCpu/maxRam/maxGpu)
+    2026-06-01 (GA)        ``storageUri`` → storageassets  omitted      flat (same as 2026-02-01-preview)
     =====================  =========================  ===========  =====================
 
-Unknown / future versions fall through to the latest known member so that new preview
+The 2026-06-01 GA contract is a strict superset of 2026-02-01-preview: the only wire
+delta is an optional ``mountProtocol`` enum field on ``InputDataMount`` / ``OutputDataMount``
+(values: ``NFS`` | ``BlobfuseCaching``). The CLI does not surface ``mountProtocol``
+as a user-facing argument today; both versions therefore share the same capability flags.
+
+Unknown / future versions fall through to the latest known member so that new
 api versions do not immediately break the CLI between releases.
 """
 
@@ -26,18 +32,25 @@ from typing import Iterator
 
 
 class ApiVersion(str, Enum):
-    """Known Discovery data-plane preview API versions."""
+    """Known Discovery data-plane API versions (previews and GA)."""
 
     V2025_07_01_PREVIEW = "2025-07-01-preview"
     V2025_12_01_PREVIEW = "2025-12-01-preview"
     V2026_02_01_PREVIEW = "2026-02-01-preview"
+    V2026_06_01 = "2026-06-01"
 
     # ---- parsing / defaults -------------------------------------------------
 
     @classmethod
     def latest(cls) -> "ApiVersion":
-        """Return the newest known API version (forward-compat fallback)."""
-        return cls.V2026_02_01_PREVIEW
+        """Return the newest known API version (forward-compat fallback).
+
+        Returning the GA version (rather than a later preview) is safe as a
+        fallback target because GA accepts every payload the prior preview
+        (2026-02-01-preview) accepted — the only wire delta is an optional
+        ``mountProtocol`` field on data mounts, which the CLI does not send.
+        """
+        return cls.V2026_06_01
 
     @classmethod
     def parse(cls, value: str | "ApiVersion" | None) -> "ApiVersion":

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/api_version.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/api_version.py
@@ -112,5 +112,20 @@ class ApiVersion(str, Enum):
         """
         return self is ApiVersion.V2025_07_01_PREVIEW
 
+    @property
+    def supports_mount_protocol(self) -> bool:
+        """True when the api-version accepts the optional ``mountProtocol`` enum on data mounts.
+
+        Added in 2026-06-01 (GA). Pre-GA api-versions reject the field via
+        ``JsonUnmappedMemberHandling.Disallow``, so this is gated as a deny-list of
+        pre-GA versions — any future version added to :class:`ApiVersion` is assumed
+        to support it (forward-compat).
+        """
+        return self not in (
+            ApiVersion.V2025_07_01_PREVIEW,
+            ApiVersion.V2025_12_01_PREVIEW,
+            ApiVersion.V2026_02_01_PREVIEW,
+        )
+
 
 __all__ = ["ApiVersion"]

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/arm_versions.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/arm_versions.py
@@ -1,0 +1,70 @@
+"""Pinned ARM (control-plane) api-versions for ``Microsoft.Discovery`` resources.
+
+The control-plane (ARM RP) api-version is **independent** of the data-plane
+api-version selected via ``discovery configure --api-version`` (see
+:mod:`models.api_version`). Both can be bumped on their own cadences — for
+example, the data plane reached GA at ``2026-06-01`` while V1 ARM resources
+were dropped from the RP schema starting at ``2026-02-01-preview``.
+
+These constants are the single source of truth for every ``az resource …``
+call the CLI makes against the Discovery RP, plus the ``outApiVersion``
+defaults baked into the ARM templates under ``poll/templates/``. Pinning
+explicitly (rather than letting the Azure CLI auto-resolve) avoids:
+
+* an extra ARM round-trip per command (``GET /providers/Microsoft.Discovery``
+  to discover supported versions),
+* silent drift when the RP registers a new api-version that subtly changes
+  response shape or accepted-properties enforcement, and
+* spurious 404s on child resource types whose auto-resolution sometimes
+  picks the parent's latest, not the child's.
+
+When the RP exposes a newer api-version, bump the relevant constant *and*
+the matching ``outApiVersion`` ``defaultValue`` in the ARM template JSON,
+then update the corresponding unit tests.
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# V2 storage family — Microsoft.Discovery/storageContainers (+ /storageAssets)
+# ---------------------------------------------------------------------------
+# Introduced at 2026-02-01-preview, GA at 2026-06-01. The GA api-version
+# adds the optional ``properties.storageStore.mountProtocol`` field but is
+# otherwise a strict superset of the preview shape, so existing templates
+# stay valid against GA without changes.
+
+STORAGECONTAINER_ARM_API_VERSION = "2026-06-01"
+STORAGEASSET_ARM_API_VERSION = "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# Nodepool reads — Microsoft.Discovery/supercomputers/{name}/nodePools/{name}
+# ---------------------------------------------------------------------------
+# In the GA resource graph per the controlplane fan-out pipeline.
+
+NODEPOOL_ARM_API_VERSION = "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# V1 datacontainer family — Microsoft.Discovery/dataContainers (+ /dataAssets)
+# ---------------------------------------------------------------------------
+# NOT exposed at 2026-06-01: the V1 resources were dropped from the RP
+# schema starting with 2026-02-01-preview, superseded by the V2 storage*
+# family. The CLI still supports a V1 cleanup path for users with legacy
+# resources; that path pins to the last api-version that exposes V1 types.
+#
+# DO NOT bump these without first verifying the resource type is registered
+# in the newer api-version (``az provider show -n Microsoft.Discovery``).
+
+DATACONTAINER_ARM_API_VERSION = "2025-07-01-preview"
+DATAASSET_ARM_API_VERSION = "2025-07-01-preview"
+
+
+__all__ = [
+    "DATAASSET_ARM_API_VERSION",
+    "DATACONTAINER_ARM_API_VERSION",
+    "NODEPOOL_ARM_API_VERSION",
+    "STORAGEASSET_ARM_API_VERSION",
+    "STORAGECONTAINER_ARM_API_VERSION",
+]

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/dataasset.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/dataasset.py
@@ -6,6 +6,13 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .arm_versions import (
+    DATAASSET_ARM_API_VERSION,
+    DATACONTAINER_ARM_API_VERSION,
+    STORAGEASSET_ARM_API_VERSION,
+    STORAGECONTAINER_ARM_API_VERSION,
+)
+
 
 class DataAssetInputs(BaseModel):
     """Input parameters for creating or deploying a data asset.
@@ -19,7 +26,7 @@ class DataAssetInputs(BaseModel):
     description: str = Field(default="", description="Description of the data asset")
     path: str = Field(description="Blob storage path for the data asset")
     api_version: str = Field(
-        default="2025-07-01-preview",
+        default=DATAASSET_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/dataContainers/dataAssets",
     )
 
@@ -33,8 +40,8 @@ class StorageAssetInputs(BaseModel):
     """Input parameters for creating or deploying a storage asset.
 
     Storage assets are the v2 equivalent of data assets, introduced in the
-    ``2026-02-01-preview`` API version. They live under
-    ``Microsoft.Discovery/storagecontainers/{name}/storageAssets/{asset}``
+    ``2026-02-01-preview`` API version and GA at ``2026-06-01``. They live
+    under ``Microsoft.Discovery/storagecontainers/{name}/storageAssets/{asset}``
     and carry the same ``description``/``path`` properties as data assets.
 
     Maps to the parameters in templates/storageasset/template.json.
@@ -52,7 +59,7 @@ class StorageAssetInputs(BaseModel):
         )
     )
     api_version: str = Field(
-        default="2026-02-01-preview",
+        default=STORAGEASSET_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/storagecontainers/storageAssets",
     )
 
@@ -107,7 +114,7 @@ class DataContainerInputs(BaseModel):
         ),
     )
     api_version: str = Field(
-        default="2025-07-01-preview",
+        default=DATACONTAINER_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/dataContainers",
     )
 
@@ -139,7 +146,7 @@ class BlobDataContainerInputs(BaseModel):
         ),
     )
     api_version: str = Field(
-        default="2025-07-01-preview",
+        default=DATACONTAINER_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/dataContainers",
     )
 
@@ -152,8 +159,9 @@ class BlobDataContainerInputs(BaseModel):
 class StorageContainerInputs(BaseModel):
     """Input parameters for creating an AzureNetAppFiles-kind storage container.
 
-    V2 (``2026-02-01-preview``) equivalent of ``DataContainerInputs``: wraps a
+    V2 equivalent of ``DataContainerInputs``: wraps a
     ``Microsoft.NetApp/netAppAccounts/capacityPools/volumes`` resource.
+    Introduced at ``2026-02-01-preview``; GA at ``2026-06-01``.
     """
 
     name: str = Field(description="Name of the storage container")
@@ -166,7 +174,7 @@ class StorageContainerInputs(BaseModel):
         ),
     )
     api_version: str = Field(
-        default="2026-02-01-preview",
+        default=STORAGECONTAINER_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/storageContainers",
     )
 
@@ -190,7 +198,7 @@ class BlobStorageContainerInputs(BaseModel):
         description="Full ARM resource ID of a Microsoft.Storage/storageAccounts to wrap.",
     )
     api_version: str = Field(
-        default="2026-02-01-preview",
+        default=STORAGECONTAINER_ARM_API_VERSION,
         description="API version for Microsoft.Discovery/storageContainers",
     )
 

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/models/tool_run.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/models/tool_run.py
@@ -5,7 +5,41 @@ Derived from sample at tests/artifacts/toolrun.json and schema toolrun.schema.js
 
 from __future__ import annotations
 
+from enum import Enum
+
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class StorageMountProtocol(str, Enum):
+    """Per-mount protocol override for the GA (2026-06-01+) data plane.
+
+    Wire values match the ``StorageMountProtocol`` enum in
+    ``Microsoft.AiForScience.Supercomputer.Common.Models.Version20260601``:
+
+    * ``NFS`` — POSIX semantics, typically backed by Azure NetApp Files.
+    * ``BlobfuseCaching`` — Blobfuse in file-cache mode, typically backed by
+      Azure Blob Storage.
+
+    Sending this on api-versions ``< 2026-06-01`` is rejected by the server
+    (``JsonUnmappedMemberHandling.Disallow``). The CLI guards against that at
+    the flag-parse layer via ``ApiVersion.supports_mount_protocol``.
+    """
+
+    NFS = "NFS"
+    BLOBFUSE_CACHING = "BlobfuseCaching"
+
+    @classmethod
+    def parse(cls, value: str) -> "StorageMountProtocol":
+        """Case-insensitive parse to a member; raises ``ValueError`` on unknown."""
+        if isinstance(value, cls):
+            return value
+        normalized = value.casefold()
+        for member in cls:
+            if member.value.casefold() == normalized:
+                return member
+        valid = ", ".join(m.value for m in cls)
+        msg = f"Invalid mount protocol {value!r}. Valid values: {valid}."
+        raise ValueError(msg)
 
 
 class InlineFile(BaseModel):
@@ -28,6 +62,11 @@ class DataMount(BaseModel):
     mount_path: str = Field(..., alias="mountPath", min_length=1)
     uri: str | None = Field(None, description="discovery://dataassets URI (api <= 2025-12-01-preview)")
     storage_uri: str | None = Field(None, alias="storageUri", description="discovery://storageassets URI (api >= 2026-02-01-preview)")
+    mount_protocol: StorageMountProtocol | None = Field(
+        None,
+        alias="mountProtocol",
+        description="Per-mount protocol override (api >= 2026-06-01). Omitted on the wire when None.",
+    )
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -123,5 +162,6 @@ __all__ = [
     "InfraOverridesFlat",
     "InlineFile",
     "ResourceSpec",
+    "StorageMountProtocol",
     "ToolRunRequest",
 ]

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/resources.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/resources.py
@@ -16,6 +16,10 @@ from typing import TYPE_CHECKING
 from discovery.common.logging import debug, error  # lightweight import (no cycle)
 
 from .azcli import run_az
+from .models.arm_versions import (
+    NODEPOOL_ARM_API_VERSION,
+    STORAGECONTAINER_ARM_API_VERSION,
+)
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -696,8 +700,9 @@ def get_storagecontainer_storagestore(storagecontainer_id: str) -> dict:
     """Return the ``properties.storageStore`` dict for a storage container resource.
 
     Storage containers are the v2 equivalent of data containers and use the
-    ``2026-02-01-preview`` API version. The ``storageStore`` shape mirrors the
-    data container ``dataStore`` shape:
+    Discovery RP's V2 ARM api-version (see
+    :data:`models.arm_versions.STORAGECONTAINER_ARM_API_VERSION`). The
+    ``storageStore`` shape mirrors the data container ``dataStore`` shape:
       - ``AzureStorageBlob``: contains ``storageAccountId``
       - ``DiscoveryStorage``: contains ``discoveryStorageId``
     """
@@ -708,7 +713,7 @@ def get_storagecontainer_storagestore(storagecontainer_id: str) -> dict:
         "--ids",
         storagecontainer_id,
         "--api-version",
-        "2026-02-01-preview",
+        STORAGECONTAINER_ARM_API_VERSION,
         "-o",
         "json",
     ]
@@ -913,7 +918,7 @@ async def _fetch_nodepool_details_async(
     from discovery.poll.dataplane_api import http_get_async, AuthHeaders
 
     url = f"https://management.azure.com{nodepool_id}"
-    params = {"api-version": "2025-07-01-preview"}
+    params = {"api-version": NODEPOOL_ARM_API_VERSION}
     headers = AuthHeaders(Authorization=f"Bearer {token}")
 
     try:

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/selection.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/selection.py
@@ -276,9 +276,12 @@ def select_api_version(env_cfg: EnvConfig) -> None:
             labels.append("latest")
         if member is current:
             labels.append("current")
+        # Distinguish previews (-preview suffix on the wire) from GA so the
+        # picker hints at stability without conflating "newest" with "stable".
+        labels.append("preview" if member.value.endswith("-preview") else "GA")
         # Container kind hint mirrors README.md guidance.
         labels.append(
-            "V1 / datacontainers" if member.uses_dataassets_uri else "V2 / storagecontainers"
+            "datacontainers" if member.uses_dataassets_uri else "storagecontainers"
         )
         options.append(f"{member.value}\t{', '.join(labels)}")
 

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storageasset/parameters.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storageasset/parameters.json
@@ -12,7 +12,7 @@
             "value": "exampleasset"
         },
         "outApiVersion": {
-            "value": "2026-02-01-preview"
+            "value": "2026-06-01"
         },
         "outStorageAssetDescription": {
             "value": ""

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storageasset/template.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storageasset/template.json
@@ -12,7 +12,7 @@
             "type": "String"
         },
         "outApiVersion": {
-            "defaultValue": "2026-02-01-preview",
+            "defaultValue": "2026-06-01",
             "type": "String"
         },
         "outStorageAssetDescription": {

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/parameters.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/parameters.json
@@ -4,7 +4,7 @@
     "parameters": {
         "outLocation": {"value": ""},
         "outStorageContainerName": {"value": ""},
-        "outApiVersion": {"value": "2026-02-01-preview"},
+        "outApiVersion": {"value": "2026-06-01"},
         "outNetAppVolumeId": {"value": ""}
     }
 }

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/parameters_blob.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/parameters_blob.json
@@ -4,7 +4,7 @@
     "parameters": {
         "outLocation": {"value": ""},
         "outStorageContainerName": {"value": ""},
-        "outApiVersion": {"value": "2026-02-01-preview"},
+        "outApiVersion": {"value": "2026-06-01"},
         "outStorageAccountId": {"value": ""}
     }
 }

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/template.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/template.json
@@ -9,7 +9,7 @@
             "type": "String"
         },
         "outApiVersion": {
-            "defaultValue": "2026-02-01-preview",
+            "defaultValue": "2026-06-01",
             "type": "String"
         },
         "outNetAppVolumeId": {

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/template_blob.json
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/templates/storagecontainer/template_blob.json
@@ -5,7 +5,7 @@
         "outLocation": {"type": "String"},
         "outStorageContainerName": {"type": "String"},
         "outApiVersion": {
-            "defaultValue": "2026-02-01-preview",
+            "defaultValue": "2026-06-01",
             "type": "String"
         },
         "outStorageAccountId": {

--- a/utilities/supercomputer-cli/discovery/tests/test_arm_versions.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_arm_versions.py
@@ -1,0 +1,185 @@
+"""Tests for the ARM api-version constants module.
+
+These constants are the single source of truth for every ``az resource …``
+call the CLI makes against the Discovery RP, plus the ``outApiVersion``
+defaults baked into the ARM templates. The tests below pin the expected
+values (cross-reference the docstrings in ``models/arm_versions.py``) and
+assert that the templates + Pydantic ``*Inputs`` models actually consume
+the constants.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib.resources import files
+
+from discovery.poll.models import arm_versions
+from discovery.poll.models.dataasset import (
+    BlobDataContainerInputs,
+    BlobStorageContainerInputs,
+    DataAssetInputs,
+    DataContainerInputs,
+    StorageAssetInputs,
+    StorageContainerInputs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pinned values — bump these tests in lockstep with arm_versions.py.
+# ---------------------------------------------------------------------------
+
+# V2 storage: GA. Bumped from 2026-02-01-preview after the controlplane RP
+# exposed 2026-06-01 with the same resource graph (verified against
+# science-controlplane swagger + integration test pipeline).
+def test_storagecontainer_arm_api_version_is_ga():
+    assert arm_versions.STORAGECONTAINER_ARM_API_VERSION == "2026-06-01"
+
+
+def test_storageasset_arm_api_version_is_ga():
+    assert arm_versions.STORAGEASSET_ARM_API_VERSION == "2026-06-01"
+
+
+# Nodepool ARM reads — supercomputer + nodepool resources are in the GA graph.
+def test_nodepool_arm_api_version_is_ga():
+    assert arm_versions.NODEPOOL_ARM_API_VERSION == "2026-06-01"
+
+
+# V1 datacontainer/dataasset are NOT exposed at 2026-06-01 (dropped from the
+# RP schema starting at 2026-02-01-preview). Pinning here documents the
+# constraint and guards against accidental future bumps that would break the
+# legacy-cleanup path.
+def test_datacontainer_arm_api_version_pinned_to_v1():
+    assert arm_versions.DATACONTAINER_ARM_API_VERSION == "2025-07-01-preview"
+
+
+def test_dataasset_arm_api_version_pinned_to_v1():
+    assert arm_versions.DATAASSET_ARM_API_VERSION == "2025-07-01-preview"
+
+
+# ---------------------------------------------------------------------------
+# Inputs models default to the right constant per resource family.
+# ---------------------------------------------------------------------------
+
+
+def test_storagecontainer_inputs_defaults_to_ga():
+    inp = StorageContainerInputs(
+        name="sc", location="eastus", netapp_volume_id="/x/y/anf/vol",
+    )
+    assert inp.api_version == arm_versions.STORAGECONTAINER_ARM_API_VERSION
+
+
+def test_blob_storagecontainer_inputs_defaults_to_ga():
+    inp = BlobStorageContainerInputs(
+        name="sc", location="eastus", storage_account_id="/x/y/storage",
+    )
+    assert inp.api_version == arm_versions.STORAGECONTAINER_ARM_API_VERSION
+
+
+def test_storageasset_inputs_defaults_to_ga():
+    inp = StorageAssetInputs(
+        name="asset", storage_container_name="sc", location="eastus", path="p/",
+    )
+    assert inp.api_version == arm_versions.STORAGEASSET_ARM_API_VERSION
+
+
+def test_datacontainer_inputs_defaults_to_v1():
+    inp = DataContainerInputs(
+        name="dc",
+        location="eastus",
+        discovery_storage_id="/x/y/storages/anf",
+        credential_identity_id="/x/y/uami",
+    )
+    assert inp.api_version == arm_versions.DATACONTAINER_ARM_API_VERSION
+
+
+def test_blob_datacontainer_inputs_defaults_to_v1():
+    inp = BlobDataContainerInputs(
+        name="dc",
+        location="eastus",
+        storage_account_id="/x/y/storage",
+        credential_identity_id="/x/y/uami",
+    )
+    assert inp.api_version == arm_versions.DATACONTAINER_ARM_API_VERSION
+
+
+def test_dataasset_inputs_defaults_to_v1():
+    inp = DataAssetInputs(
+        name="da", data_container_name="dc", location="eastus", path="p/",
+    )
+    assert inp.api_version == arm_versions.DATAASSET_ARM_API_VERSION
+
+
+# ---------------------------------------------------------------------------
+# ARM template JSON files — outApiVersion defaultValue must match the constant.
+# These guard against drift between Python and template payloads.
+# ---------------------------------------------------------------------------
+
+
+def _read_template(rel: str) -> dict:
+    return json.loads(files("discovery.poll").joinpath(f"templates/{rel}").read_text())
+
+
+def _read_parameters(rel: str) -> dict:
+    return json.loads(files("discovery.poll").joinpath(f"templates/{rel}").read_text())
+
+
+def test_storagecontainer_template_pinned_to_ga():
+    tmpl = _read_template("storagecontainer/template.json")
+    assert tmpl["parameters"]["outApiVersion"]["defaultValue"] == (
+        arm_versions.STORAGECONTAINER_ARM_API_VERSION
+    )
+
+
+def test_storagecontainer_blob_template_pinned_to_ga():
+    tmpl = _read_template("storagecontainer/template_blob.json")
+    assert tmpl["parameters"]["outApiVersion"]["defaultValue"] == (
+        arm_versions.STORAGECONTAINER_ARM_API_VERSION
+    )
+
+
+def test_storagecontainer_parameters_pinned_to_ga():
+    params = _read_parameters("storagecontainer/parameters.json")
+    assert params["parameters"]["outApiVersion"]["value"] == (
+        arm_versions.STORAGECONTAINER_ARM_API_VERSION
+    )
+
+
+def test_storagecontainer_parameters_blob_pinned_to_ga():
+    params = _read_parameters("storagecontainer/parameters_blob.json")
+    assert params["parameters"]["outApiVersion"]["value"] == (
+        arm_versions.STORAGECONTAINER_ARM_API_VERSION
+    )
+
+
+def test_storageasset_template_pinned_to_ga():
+    tmpl = _read_template("storageasset/template.json")
+    assert tmpl["parameters"]["outApiVersion"]["defaultValue"] == (
+        arm_versions.STORAGEASSET_ARM_API_VERSION
+    )
+
+
+def test_storageasset_parameters_pinned_to_ga():
+    params = _read_parameters("storageasset/parameters.json")
+    assert params["parameters"]["outApiVersion"]["value"] == (
+        arm_versions.STORAGEASSET_ARM_API_VERSION
+    )
+
+
+# ---------------------------------------------------------------------------
+# V1 templates: keep pinned to V1 — bumping to GA would break (resource type
+# not in the GA RP schema). These tests guard against accidental bumps.
+# ---------------------------------------------------------------------------
+
+
+def test_datacontainer_template_pinned_to_v1():
+    tmpl = _read_template("datacontainer/template.json")
+    assert tmpl["parameters"]["outApiVersion"]["defaultValue"] == (
+        arm_versions.DATACONTAINER_ARM_API_VERSION
+    )
+
+
+def test_dataasset_template_pinned_to_v1():
+    tmpl = _read_template("dataasset/template.json")
+    assert tmpl["parameters"]["outApiVersion"]["defaultValue"] == (
+        arm_versions.DATAASSET_ARM_API_VERSION
+    )

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_history.py
@@ -788,7 +788,9 @@ class TestCancelSince:
         """Install a no-op cancel_operation that records the IDs it was called with."""
         called: list[str] = []
 
-        def fake_cancel(project, op_id, workspace_url, *, api_version):
+        def fake_cancel(project, op_id, workspace_url, *, api_version, **_kwargs):
+            # Accept and ignore newer keyword args (``wait``, ``wait_timeout_seconds``)
+            # so this stub keeps working as the signature evolves.
             called.append(op_id)
 
         monkeypatch.setattr(

--- a/utilities/supercomputer-cli/discovery/tests/test_deploy_storageasset.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_deploy_storageasset.py
@@ -38,7 +38,7 @@ class TestRenderStorageassetParameters:
         assert params["parameters"]["outStorageAssetName"]["value"] == "test-asset"
         assert params["parameters"]["outStorageAssetDescription"]["value"] == "Test storage asset"
         assert params["parameters"]["outStorageAssetPath"]["value"] == "test-asset/"
-        assert params["parameters"]["outApiVersion"]["value"] == "2026-02-01-preview"
+        assert params["parameters"]["outApiVersion"]["value"] == "2026-06-01"
 
     def test_render_custom_api_version(self) -> None:
         inputs = StorageAssetInputs(

--- a/utilities/supercomputer-cli/discovery/tests/test_deploy_storagecontainer.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_deploy_storagecontainer.py
@@ -34,7 +34,7 @@ class TestRender:
         params = deploy_storagecontainer.render_storagecontainer_parameters(_default_inputs())
         assert params["parameters"]["outLocation"]["value"] == "uksouth"
         assert params["parameters"]["outStorageContainerName"]["value"] == "scratch-sc-test"
-        assert params["parameters"]["outApiVersion"]["value"] == "2026-02-01-preview"
+        assert params["parameters"]["outApiVersion"]["value"] == "2026-06-01"
         assert params["parameters"]["outNetAppVolumeId"]["value"].endswith("/volumes/vol1")
 
 

--- a/utilities/supercomputer-cli/discovery/tests/test_ga_api_surface.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_ga_api_surface.py
@@ -1,0 +1,365 @@
+"""Tests for the 2026-06-01 GA-specific surfaces.
+
+Covers:
+* ``StorageMountProtocol`` enum + ``DataMount.mount_protocol`` wire serialization.
+* ``ApiVersion.supports_mount_protocol`` capability flag.
+* ``_parse_mount_protocol_or_exit`` flag-parse helper (validation + fast-fail).
+* ``cancel_operation(wait=True/False)`` semantics, including:
+    - polls until the operation reaches a positive terminal state.
+    - treats a 404 during the wait phase as terminal success.
+    - raises :class:`CancelWaitTimeoutError` (subclass of ``PollError``) on timeout.
+    - default ``wait=False`` is preserved so ``JobClient.cancel`` keeps its
+      fire-and-forget contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import typer
+
+from discovery.poll import cli_submit, dataplane_api
+from discovery.poll.dataplane_api import (
+    _TERMINAL_OPERATION_STATES,
+    CancelWaitTimeoutError,
+    PollError,
+    cancel_operation,
+)
+from discovery.poll.models.api_version import ApiVersion
+from discovery.poll.models.tool_run import DataMount, StorageMountProtocol
+
+
+# ---------------------------------------------------------------------------
+# StorageMountProtocol enum
+# ---------------------------------------------------------------------------
+
+
+def test_storage_mount_protocol_wire_values():
+    """Enum values must match the GA swagger exactly (server uses Disallow on unknowns)."""
+    assert StorageMountProtocol.NFS.value == "NFS"
+    assert StorageMountProtocol.BLOBFUSE_CACHING.value == "BlobfuseCaching"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("NFS", StorageMountProtocol.NFS),
+        ("nfs", StorageMountProtocol.NFS),
+        ("Nfs", StorageMountProtocol.NFS),
+        ("BlobfuseCaching", StorageMountProtocol.BLOBFUSE_CACHING),
+        ("blobfusecaching", StorageMountProtocol.BLOBFUSE_CACHING),
+        ("BLOBFUSECACHING", StorageMountProtocol.BLOBFUSE_CACHING),
+    ],
+)
+def test_storage_mount_protocol_parse_case_insensitive(raw, expected):
+    """User-supplied CLI values are normalized to the wire casing."""
+    assert StorageMountProtocol.parse(raw) is expected
+
+
+def test_storage_mount_protocol_parse_rejects_unknown():
+    """Unknown values raise ``ValueError`` with the valid value list in the message."""
+    with pytest.raises(ValueError, match="Valid values: NFS, BlobfuseCaching"):
+        StorageMountProtocol.parse("SMB")
+
+
+# ---------------------------------------------------------------------------
+# DataMount.mount_protocol wire serialization
+# ---------------------------------------------------------------------------
+
+
+def test_datamount_omits_mountprotocol_when_none():
+    """Default ``None`` must be omitted from the wire (server rejects unknown fields)."""
+    mount = DataMount(mountPath="/x", storageUri="discovery://storageassets/foo")
+    payload = json.loads(mount.model_dump_json(by_alias=True, exclude_none=True))
+    assert "mountProtocol" not in payload
+    assert payload == {"mountPath": "/x", "storageUri": "discovery://storageassets/foo"}
+
+
+@pytest.mark.parametrize(
+    ("protocol", "wire"),
+    [
+        (StorageMountProtocol.NFS, "NFS"),
+        (StorageMountProtocol.BLOBFUSE_CACHING, "BlobfuseCaching"),
+    ],
+)
+def test_datamount_serializes_mountprotocol_with_wire_casing(protocol, wire):
+    """Wire payload must use the canonical casing the server enum expects."""
+    mount = DataMount(
+        mountPath="/x",
+        storageUri="discovery://storageassets/foo",
+        mountProtocol=protocol,
+    )
+    payload = json.loads(mount.model_dump_json(by_alias=True, exclude_none=True))
+    assert payload["mountProtocol"] == wire
+
+
+# ---------------------------------------------------------------------------
+# ApiVersion.supports_mount_protocol capability flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2025-07-01-preview", False),
+        ("2025-12-01-preview", False),
+        ("2026-02-01-preview", False),
+        ("2026-06-01", True),
+    ],
+)
+def test_supports_mount_protocol(version, expected):
+    """Only GA (and any forward-compat versions) accept mountProtocol on the wire."""
+    assert ApiVersion.parse(version).supports_mount_protocol is expected
+
+
+def test_supports_mount_protocol_unknown_falls_back_to_latest():
+    """Unknown / future versions inherit support via the deny-list pattern."""
+    assert ApiVersion.parse("2099-01-01").supports_mount_protocol is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_mount_protocol_or_exit CLI helper
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mount_protocol_none_returns_none():
+    """No flag → no override (use storage container's default protocol)."""
+    av = ApiVersion.V2026_06_01
+    assert cli_submit._parse_mount_protocol_or_exit(None, av) is None
+    assert cli_submit._parse_mount_protocol_or_exit("", av) is None
+
+
+def test_parse_mount_protocol_returns_enum_member():
+    """Recognised values produce the matching :class:`StorageMountProtocol`."""
+    av = ApiVersion.V2026_06_01
+    assert cli_submit._parse_mount_protocol_or_exit("NFS", av) is StorageMountProtocol.NFS
+    assert (
+        cli_submit._parse_mount_protocol_or_exit("blobfusecaching", av)
+        is StorageMountProtocol.BLOBFUSE_CACHING
+    )
+
+
+@pytest.mark.parametrize(
+    "av",
+    [
+        ApiVersion.V2025_07_01_PREVIEW,
+        ApiVersion.V2025_12_01_PREVIEW,
+        ApiVersion.V2026_02_01_PREVIEW,
+    ],
+)
+def test_parse_mount_protocol_rejects_on_pre_ga(av):
+    """Passing the flag on a pre-GA api-version exits 2 with a clear message."""
+    with pytest.raises(typer.Exit) as exc_info:
+        cli_submit._parse_mount_protocol_or_exit("NFS", av)
+    assert exc_info.value.exit_code == 2
+
+
+def test_parse_mount_protocol_rejects_unknown_value():
+    """Unknown protocol on a supported api-version still exits 2 (bad value)."""
+    with pytest.raises(typer.Exit) as exc_info:
+        cli_submit._parse_mount_protocol_or_exit("SMB", ApiVersion.V2026_06_01)
+    assert exc_info.value.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# CancelWaitTimeoutError exception
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_wait_timeout_is_pollerror_subclass():
+    """Back-compat: existing ``except PollError`` blocks still catch the new exception."""
+    assert issubclass(CancelWaitTimeoutError, PollError)
+
+
+def test_terminal_states_match_swagger():
+    """Allow-list mirrors the Azure.Core.Foundations.OperationState terminal members."""
+    assert frozenset({"Succeeded", "Failed", "Canceled"}) == _TERMINAL_OPERATION_STATES
+
+
+# ---------------------------------------------------------------------------
+# cancel_operation(wait=...) behavior
+# ---------------------------------------------------------------------------
+
+
+def _stub_response(status: str, op_id: str = "op-xyz"):
+    """Build a ToolExecutionResponse-shaped object whose only attribute we use is `.status`."""
+
+    class _Stub:
+        pass
+
+    s = _Stub()
+    s.id = op_id
+    s.status = status
+    s.result = None
+    s.error = None
+    return s
+
+
+def test_cancel_operation_default_is_fire_and_forget(monkeypatch):
+    """Library default must remain ``wait=False`` so JobClient.cancel doesn't silently block.
+
+    Regression guard for the rubber-duck B1 finding: flipping the default would
+    break every programmatic SDK caller in ``api.py``.
+    """
+    post_calls: list[dict] = []
+    poll_calls: list[tuple] = []
+
+    def fake_post(**kwargs):
+        post_calls.append(kwargs)
+        return {}
+
+    def fake_status(*args, **kwargs):
+        poll_calls.append((args, kwargs))
+        return _stub_response("Running")
+
+    monkeypatch.setattr(dataplane_api, "_http_post", fake_post)
+    monkeypatch.setattr(dataplane_api, "get_operation_status", fake_status)
+    monkeypatch.setattr(dataplane_api, "get_access_token", lambda *a, **kw: "tok")
+
+    result = cancel_operation(
+        "proj", "op-xyz", "https://workspace", api_version="2026-06-01",
+    )
+
+    assert result is None
+    assert len(post_calls) == 1
+    # Crucially: no status polling without wait=True.
+    assert poll_calls == []
+
+
+def test_cancel_operation_wait_polls_until_terminal(monkeypatch):
+    """``wait=True`` calls get_operation_status until status is in the terminal allow-list."""
+    statuses = iter(["Running", "Running", "Canceled"])
+    poll_calls: list[tuple] = []
+
+    monkeypatch.setattr(dataplane_api, "_http_post", lambda **kw: {})
+    monkeypatch.setattr(dataplane_api, "get_access_token", lambda *a, **kw: "tok")
+    monkeypatch.setattr(dataplane_api, "time", _FakeTime())
+
+    def fake_status(*args, **kwargs):
+        poll_calls.append((args, kwargs))
+        return _stub_response(next(statuses))
+
+    monkeypatch.setattr(dataplane_api, "get_operation_status", fake_status)
+
+    result = cancel_operation(
+        "proj", "op-xyz", "https://workspace",
+        api_version="2026-06-01", wait=True,
+    )
+
+    assert result == "Canceled"
+    # Three polls: Running, Running, Canceled.
+    assert len(poll_calls) == 3
+
+
+def test_cancel_operation_wait_treats_404_as_terminal(monkeypatch):
+    """A 404 during the wait phase means the op was reaped — cancel goal achieved."""
+    monkeypatch.setattr(dataplane_api, "_http_post", lambda **kw: {})
+    monkeypatch.setattr(dataplane_api, "get_access_token", lambda *a, **kw: "tok")
+    monkeypatch.setattr(dataplane_api, "time", _FakeTime())
+
+    fake_response = httpx.Response(
+        status_code=404,
+        request=httpx.Request("GET", "https://example/status"),
+        content=b"{}",
+    )
+    err = httpx.HTTPStatusError(
+        message="not found", request=fake_response.request, response=fake_response,
+    )
+
+    def fake_status(*args, **kwargs):
+        raise err
+
+    monkeypatch.setattr(dataplane_api, "get_operation_status", fake_status)
+
+    result = cancel_operation(
+        "proj", "op-xyz", "https://workspace",
+        api_version="2026-06-01", wait=True,
+    )
+    # Synthetic terminal status: cancel goal satisfied.
+    assert result == "Canceled"
+
+
+def test_cancel_operation_wait_reraises_non_404_http_errors(monkeypatch):
+    """500 during the wait phase is a real failure, not a synthetic-terminal case."""
+    monkeypatch.setattr(dataplane_api, "_http_post", lambda **kw: {})
+    monkeypatch.setattr(dataplane_api, "get_access_token", lambda *a, **kw: "tok")
+    monkeypatch.setattr(dataplane_api, "time", _FakeTime())
+
+    fake_response = httpx.Response(
+        status_code=500,
+        request=httpx.Request("GET", "https://example/status"),
+        content=b"{}",
+    )
+    err = httpx.HTTPStatusError(
+        message="boom", request=fake_response.request, response=fake_response,
+    )
+
+    monkeypatch.setattr(
+        dataplane_api,
+        "get_operation_status",
+        lambda *a, **kw: (_ for _ in ()).throw(err),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        cancel_operation(
+            "proj", "op-xyz", "https://workspace",
+            api_version="2026-06-01", wait=True,
+        )
+
+
+def test_cancel_operation_wait_raises_timeout(monkeypatch):
+    """If the operation never reaches a terminal state within budget, raise CancelWaitTimeoutError."""
+    monkeypatch.setattr(dataplane_api, "_http_post", lambda **kw: {})
+    monkeypatch.setattr(dataplane_api, "get_access_token", lambda *a, **kw: "tok")
+    monkeypatch.setattr(dataplane_api, "time", _FakeTime(advance_per_call=10.0))
+    monkeypatch.setattr(
+        dataplane_api,
+        "get_operation_status",
+        lambda *a, **kw: _stub_response("Running"),
+    )
+
+    with pytest.raises(CancelWaitTimeoutError) as exc_info:
+        cancel_operation(
+            "proj", "op-xyz", "https://workspace",
+            api_version="2026-06-01", wait=True, wait_timeout_seconds=5,
+        )
+    assert "op-xyz" in str(exc_info.value)
+    assert "5s" in str(exc_info.value)
+
+
+def test_cancel_operation_requires_project_and_id():
+    with pytest.raises(PollError):
+        cancel_operation("", "op", "https://w", api_version="2026-06-01")
+    with pytest.raises(PollError):
+        cancel_operation("proj", "", "https://w", api_version="2026-06-01")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTime:
+    """Module-replacement that lets the cancel-wait loop run without real sleeping.
+
+    The cancel-wait loop calls ``time.time()`` for elapsed checks and ``time.sleep()``
+    between polls. We replace the whole ``time`` module reference inside
+    ``dataplane_api`` with this fake so tests stay deterministic and fast.
+    """
+
+    def __init__(self, advance_per_call: float = 0.0):
+        self._now = 0.0
+        self._advance = advance_per_call
+
+    def time(self) -> float:
+        result = self._now
+        self._now += self._advance
+        return result
+
+    def sleep(self, seconds: float) -> None:
+        # Bump the clock by the requested duration so timeouts can be reached
+        # without real wall-clock delay. When the test sets advance_per_call > 0
+        # the clock already moves on each time() read, so this is additive.
+        self._now += seconds

--- a/utilities/supercomputer-cli/discovery/tests/test_poll_module.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_poll_module.py
@@ -392,10 +392,12 @@ def test_api_version_enum_uses_storage_id():
 
 
 def test_api_version_enum_modern_omits_storage_id():
-    """2026-02-01-preview uses storageUri on the data mounts, not top-level storageId."""
+    """2026-02-01-preview and 2026-06-01 (GA) use storageUri on the data mounts, not top-level storageId."""
     from discovery.poll.models.api_version import ApiVersion
     assert not ApiVersion.parse("2026-02-01-preview").uses_storage_id
     assert not ApiVersion.parse("2026-02-01-preview").uses_dataassets_uri
+    assert not ApiVersion.parse("2026-06-01").uses_storage_id
+    assert not ApiVersion.parse("2026-06-01").uses_dataassets_uri
 
 
 def test_api_version_enum_nested_infra_overrides():
@@ -404,6 +406,20 @@ def test_api_version_enum_nested_infra_overrides():
     assert ApiVersion.parse("2025-07-01-preview").uses_nested_infra_overrides
     assert not ApiVersion.parse("2025-12-01-preview").uses_nested_infra_overrides
     assert not ApiVersion.parse("2026-02-01-preview").uses_nested_infra_overrides
+    assert not ApiVersion.parse("2026-06-01").uses_nested_infra_overrides
+
+
+def test_api_version_enum_ga_is_latest():
+    """The GA version (2026-06-01) is the newest known member and the fallback target."""
+    from discovery.poll.models.api_version import ApiVersion
+    assert ApiVersion.latest() is ApiVersion.V2026_06_01
+    assert ApiVersion.parse("2026-06-01") is ApiVersion.V2026_06_01
+    # GA shares the modern (V2) capability flags with 2026-02-01-preview:
+    # no storageId, storageassets URIs, flat infraOverrides.
+    ga = ApiVersion.V2026_06_01
+    assert not ga.uses_storage_id
+    assert not ga.uses_dataassets_uri
+    assert not ga.uses_nested_infra_overrides
 
 
 def test_api_version_enum_unknown_falls_back_to_latest():
@@ -424,6 +440,7 @@ def test_legacy_api_versions_backcompat_shim():
     assert "2025-07-01-preview" in _LEGACY_API_VERSIONS
     assert "2025-12-01-preview" in _LEGACY_API_VERSIONS
     assert "2026-02-01-preview" not in _LEGACY_API_VERSIONS
+    assert "2026-06-01" not in _LEGACY_API_VERSIONS
     assert _NESTED_INFRA_OVERRIDES_API_VERSIONS == frozenset({"2025-07-01-preview"})
 
 

--- a/utilities/supercomputer-cli/discovery/tests/test_scratch_mount.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_scratch_mount.py
@@ -40,11 +40,16 @@ def test_build_scratch_mount_v1(tmp_path) -> None:
     assert mount.storage_uri is None
 
 
-def test_build_scratch_mount_v2(tmp_path) -> None:
+# Parametrize V2 (storagecontainer) paths across the 2026-02-01-preview and
+# 2026-06-01 (GA) API versions: both must dispatch to the storage_uri branch.
+_V2_API_VERSIONS = [ApiVersion.V2026_02_01_PREVIEW, ApiVersion.V2026_06_01]
+
+
+@pytest.mark.parametrize("av", _V2_API_VERSIONS)
+def test_build_scratch_mount_v2(tmp_path, av) -> None:
     env = EnvConfig(path=tmp_path / ".env")
     env.supercomputer_scratch_scs = {SC_ID: SC_CONTAINER_ID}
     np_info = _np()
-    av = ApiVersion.V2026_02_01_PREVIEW
 
     mount = cli_submit._build_scratch_mount(np_info, env, av)
     assert mount is not None
@@ -55,11 +60,11 @@ def test_build_scratch_mount_v2(tmp_path) -> None:
     )
 
 
-def test_build_scratch_mount_returns_none_when_unmapped(tmp_path) -> None:
+@pytest.mark.parametrize("av", [ApiVersion.V2025_07_01_PREVIEW, *_V2_API_VERSIONS])
+def test_build_scratch_mount_returns_none_when_unmapped(tmp_path, av) -> None:
     env = EnvConfig(path=tmp_path / ".env")
     np_info = _np()
-    assert cli_submit._build_scratch_mount(np_info, env, ApiVersion.V2025_07_01_PREVIEW) is None
-    assert cli_submit._build_scratch_mount(np_info, env, ApiVersion.V2026_02_01_PREVIEW) is None
+    assert cli_submit._build_scratch_mount(np_info, env, av) is None
 
 
 def test_scratch_mount_or_exit_returns_none_when_flag_off(tmp_path) -> None:
@@ -73,22 +78,24 @@ def test_scratch_mount_or_exit_returns_none_when_flag_off(tmp_path) -> None:
     )
 
 
-def test_scratch_mount_or_exit_exits_when_flag_on_but_unmapped(tmp_path) -> None:
+@pytest.mark.parametrize("av", _V2_API_VERSIONS)
+def test_scratch_mount_or_exit_exits_when_flag_on_but_unmapped(tmp_path, av) -> None:
     env = EnvConfig(path=tmp_path / ".env")
     np_info = _np()
     with pytest.raises(typer.Exit) as exc:
         cli_submit._scratch_mount_or_exit(
-            np_info, env, ApiVersion.V2026_02_01_PREVIEW, scratch=True,
+            np_info, env, av, scratch=True,
         )
     assert exc.value.exit_code == 2
 
 
-def test_scratch_mount_or_exit_returns_mount_when_mapped(tmp_path) -> None:
+@pytest.mark.parametrize("av", _V2_API_VERSIONS)
+def test_scratch_mount_or_exit_returns_mount_when_mapped(tmp_path, av) -> None:
     env = EnvConfig(path=tmp_path / ".env")
     env.supercomputer_scratch_scs = {SC_ID: SC_CONTAINER_ID}
     np_info = _np()
     mount = cli_submit._scratch_mount_or_exit(
-        np_info, env, ApiVersion.V2026_02_01_PREVIEW, scratch=True,
+        np_info, env, av, scratch=True,
     )
     assert mount is not None
     assert mount.mount_path == "/scratch"
@@ -108,25 +115,26 @@ def test_no_cross_sc_fallback_v1(tmp_path) -> None:
         )
 
 
-def test_no_cross_sc_fallback_v2(tmp_path) -> None:
+@pytest.mark.parametrize("av", _V2_API_VERSIONS)
+def test_no_cross_sc_fallback_v2(tmp_path, av) -> None:
     """V2: a wrapper mapped for a *different* SC must not be silently used."""
     env = EnvConfig(path=tmp_path / ".env")
     other_sc_id = SC_ID.replace("/sc1", "/sc2")
     env.supercomputer_scratch_scs = {other_sc_id: SC_CONTAINER_ID}
     np_info = _np()
 
-    assert cli_submit._build_scratch_mount(np_info, env, ApiVersion.V2026_02_01_PREVIEW) is None
+    assert cli_submit._build_scratch_mount(np_info, env, av) is None
     with pytest.raises(typer.Exit):
         cli_submit._scratch_mount_or_exit(
-            np_info, env, ApiVersion.V2026_02_01_PREVIEW, scratch=True,
+            np_info, env, av, scratch=True,
         )
 
 
-def test_no_resolution_when_np_info_missing(tmp_path) -> None:
+@pytest.mark.parametrize("av", [ApiVersion.V2025_07_01_PREVIEW, *_V2_API_VERSIONS])
+def test_no_resolution_when_np_info_missing(tmp_path, av) -> None:
     """If we can't identify which SC the run lands on, we cannot resolve a wrapper."""
     env = EnvConfig(path=tmp_path / ".env")
     env.supercomputer_scratch_dcs = {SC_ID: DC_ID}
     env.supercomputer_scratch_scs = {SC_ID: SC_CONTAINER_ID}
 
-    assert cli_submit._build_scratch_mount(None, env, ApiVersion.V2025_07_01_PREVIEW) is None
-    assert cli_submit._build_scratch_mount(None, env, ApiVersion.V2026_02_01_PREVIEW) is None
+    assert cli_submit._build_scratch_mount(None, env, av) is None


### PR DESCRIPTION
## Summary

Adds the Discovery `2026-06-01` GA api-version to the supercomputer CLI across both the **data plane** (tool execution) and the **control plane** (Microsoft.Discovery RP ARM resources), and wires up the GA-only `mountProtocol` and Operation-Location LRO behaviors.

Three commits, each independently reviewable:

1. **`5469a85`** — Add 2026-06-01 GA data-plane API version
   `ApiVersion.V2026_06_01` enum member, `latest()` bumped, capability flags identical to `2026-02-01-preview` (the wire diff is solely the new optional `mountProtocol` field). Picker labels gain `preview` / `GA` tags. README + `--api-version` help text examples bumped.

2. **`937d3fd`** — Wire `--mount-protocol` flag and cancel-wait polling for GA
   * `StorageMountProtocol` str-enum (`NFS` | `BlobfuseCaching`) + `DataMount.mount_protocol` field; case-insensitive `--mount-protocol` flag on `start` / `batch` / `vscode`; fast-fail (exit 2) when the configured api-version pre-dates GA via the new `ApiVersion.supports_mount_protocol` capability flag.
   * `cancel_operation(wait: bool = False, wait_timeout_seconds: int = 120)` — library default stays fire-and-forget (preserves `JobClient.cancel` SDK contract); CLI single-op `discovery job cancel <id>` opts in to `wait=True`. Uses a **positive** terminal allow-list `{Succeeded, Failed, Canceled}` (matches `Azure.Core.Foundations.OperationState`); 404 during the wait phase is treated as terminal success; `CancelWaitTimeoutError(PollError)` raised on budget exhaustion → CLI exits 0 with a warning + status-check suggestion. New `--no-wait` and `--wait-timeout` flags.

3. **`c7a971c`** — Pin Discovery RP ARM api-versions to GA and centralize
   New `models/arm_versions.py` is the single source of truth for every `az resource …` call and every ARM template `outApiVersion`. V2 storage family + nodepool → `2026-06-01`. V1 datacontainer / dataasset family stays at `2025-07-01-preview` (V1 resources were dropped from the RP schema starting at `2026-02-01-preview`; bumping would 404). Replaces 7 scattered magic strings with named constants; refreshes 2 stale "preview-only" docstrings; bumps 6 storage ARM template JSONs to `2026-06-01`.

## Source-of-truth verification

* **Data plane**: `science-supercomputer/src/Common/CommonUtils/Constants.cs` defines `ApiVersion20260601 = "2026-06-01"`. The only wire schema delta vs `2026-02-01-preview` is the optional `mountProtocol` enum on `InputDataMount` / `OutputDataMount` (verified via `discovery-workspace.json` swagger + `Version20260601/ToolRunRequest.cs` diff).
* **Cancel-LRO change**: `science-supercomputer/src/data-plane/ApiControllers/Controllers/ToolRunController.cs:2132-2184` is the only `IsAtLeast(…, ApiVersion20260601)` gate in the data plane — pre-GA cancel returns empty 202, GA returns 202 + body + `Operation-Location`. CLI fire-and-forget previously ignored both; new wait path polls the operation regardless of version (works against pre-GA too since the operation state machine is unchanged).
* **Control plane**: `science-controlplane/.pipelines/Templates/Vars/api-versions/2026-06-01.yaml` has `status: active` and exercises `StorageContainer` / `StorageAsset` / `NodePool` / `SuperComputer` / `Workspace` / `Project` / `Tool` / `Bookshelf` / `ChatModelDeployment` at `2026-06-01` against prod regions (eastus / swedencentral / uksouth / eastus2). V1 dataContainer / dataAsset are absent from `swagger-2026-02-01-preview/discovery.json` — confirmed pinning V1 helpers to `2025-07-01-preview` is correct.
* **Manual smoke** against live Discovery RP: `discovery configure --nodepool` (nodepool @ 2026-06-01), `--archive-select` → V2 storagecontainer listing + `get_storagecontainer_storagestore` @ 2026-06-01, ARM template-based `StorageAsset` deploy @ 2026-06-01 — all clean.

## Test coverage

* `tests/test_ga_api_surface.py` (new, 30 tests) — `StorageMountProtocol` enum + parse, `DataMount.mountProtocol` wire serialization, `ApiVersion.supports_mount_protocol` capability flag, `_parse_mount_protocol_or_exit` validation/fast-fail, `cancel_operation(wait=…)` poll-until-terminal + 404-as-terminal + timeout-raises-typed-error, and a regression guard that the library default stays `wait=False` (B1 from rubber-duck — prevents silent break of `JobClient.cancel`).
* `tests/test_arm_versions.py` (new, 19 tests) — pins every ARM constant, every `*Inputs` Pydantic default, and every storage/V1 template's `outApiVersion` to the matching constant. V1-stays-V1 is a positive assertion to block accidental future bumps.
* `tests/test_scratch_mount.py` — existing V2 tests parametrized across `V2026_02_01_PREVIEW` and `V2026_06_01`.
* `tests/test_poll_module.py` — `test_api_version_enum_ga_is_latest` added; existing modern/nested/shim tests extended to assert GA.
* `tests/test_deploy_storageasset.py` / `test_deploy_storagecontainer.py` — `outApiVersion` expectations bumped to `2026-06-01`.
* `tests/test_cli_history.py` — fake `cancel_operation` fixture absorbs new kwargs (no behavior change).
* Full local test suite (~620 tests) passes. Pre-existing failures from missing `tests/artifacts/` JSON fixtures are unaffected.

## Backward compat / things explicitly NOT changed

* `EnvConfig.api_version` default stays `2025-07-01-preview` — users with no config get the legacy default; their existing configs are honored unchanged.
* `JobClient.cancel` library entrypoint behavior stays fire-and-forget. Only the CLI single-op cancel path opts in to `wait=True`.
* Bulk `discovery job cancel --since` stays `wait=False` for throughput (documented in `--since` help text).
* `cancel_operation` library default stays `wait=False` (B1 fix from rubber-duck review).
* V1 dataContainer / dataAsset / cleanup helpers stay at `2025-07-01-preview` — those resource types were dropped from the GA RP schema; bumping would 404 every cleanup call.

## Risk

Low. ARM bumps verified against live RP. Data-plane GA is a strict superset of `2026-02-01-preview`. Capability flags identical between preview and GA for the dimensions the CLI dispatches on. The cancel-wait default-flip is contained to the CLI layer (one new CLI flag), not the library.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)
