### PR TITLE
Add new code owners to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,15 +7,15 @@
 # See https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customization/customizing-your-repository/about-code-owners
 
 # Default reviewers — applied when no more-specific rule matches.
-*                                       @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
+*                                       @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
 
 # CI / workflow tooling
-/.github/workflows/                     @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
-/.github/scripts/                       @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
-/.github/CODEOWNERS                     @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
+/.github/workflows/                     @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
+/.github/scripts/                       @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
+/.github/CODEOWNERS                     @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
 
 # Schema files — changes here can break every agent/kit in the catalog.
-/docs/schemas/                          @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
+/docs/schemas/                          @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
 
 # Auto-generated registries — should normally never be hand-edited (see POL-011).
 # `discovery-registry-bot` is the GitHub App that authors the chore/registry-refresh*
@@ -25,11 +25,11 @@
 # approve its own PRs (GitHub forbids self-approval), so this line is structural
 # prep for fully-automated registry merges; until a second identity is wired up,
 # a human codeowner from the list below still needs to approve.
-/.auto-registry/                        @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney @discovery-registry-bot
+/.auto-registry/                        @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer @discovery-registry-bot
 
 # Per-content area
-/agents/                                @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
-/starter-kits/                          @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
+/agents/                                @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
+/starter-kits/                          @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer
 
 # Operator utilities for Discovery services (PowerShell scripts).
-/utilities/                             @mukesh-dua @charwen @leijgao @ffrachon @karthikananth @anzaman @surajmb @prashney
+/utilities/                             @mukesh-dua @charwen @leijgao @karthikananth @anzaman @surajmb @prashney @umamaheshmsft @cjtozer


### PR DESCRIPTION
## Summary
This pull request updates the `.github/CODEOWNERS` file to reflect changes in code ownership across several areas of the repository. The main change is the addition of `@umamaheshmsft` and `@cjtozer` as code owners for multiple directories and files, while removing `@ffrachon` from those same areas.

Ownership updates:

* Added `@umamaheshmsft` and `@cjtozer` as code owners for the repository default, CI/workflow tooling, schema files, auto-registry, agents, starter kits, and utilities directories.
* Removed `@ffrachon` as a code owner from the same areas listed above.

## Type of change

<!-- Tick all that apply. -->

- [ ] New agent (under `agents/<name>/`)
- [ ] Update to an existing agent
- [ ] New starter kit (under `starter-kits/<name>/`)
- [ ] Update to an existing starter kit
- [ ] Schema change (`docs/schemas/**`)
- [ ] Workflow / script change (`.github/**`)
- [x] Documentation only
- [ ] Other (describe below)

## Related issue / tracking

<!-- e.g. Fixes #123, refs https://… . If none, write "n/a". -->

## Schema impact

- [x] No schema changes
- [ ] Schema changes are backward compatible
- [ ] Schema changes are **breaking** — add the `breaking-change` label and link the rollout plan below

<!-- For breaking changes, link the rollout / migration plan: -->

## Validation checklist

- [x] Documentation (`README.md`, schemas) is updated to match the change.
- [x] No hand-edits to `.auto-registry/**` (it is generated post-merge).
- [x] No OS / editor artefacts committed (`.DS_Store`, `.env`, `*.swp`, `.idea/`, `.vs/`, etc.).
- [x] If model-weight files are added, they are Git-LFS tracked, ≤5 GB each, and in an allowed format.
- [x] No secrets, customer data, or internal-only URLs are committed.
- [x] All Markdown links resolve.

## Reviewer notes (optional)

<!-- Anything reviewers should focus on, known gaps, follow-up work, etc. -->
