### PR TITLE
Don't truncate batch commands in final output

### DIFF
--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_submit.py
@@ -921,9 +921,11 @@ def batch(
             idx, op_id, err = future.result()
             completed_count += 1
             if op_id:
-                cmd_preview = command_list[idx][:80]
                 successful_jobs.append((idx, op_id, command_list[idx]))
-                info(f"  [{completed_count}/{total}] {op_id}  {cmd_preview}")
+                # Print the full command. Rich's Console soft-wraps to
+                # terminal width; the `[n/total] op-id ` prefix anchors
+                # each entry visually even when the command wraps.
+                info(f"  [{completed_count}/{total}] {op_id}  {command_list[idx]}")
             else:
                 failed_jobs.append((idx, err or "Unknown error"))
                 error(f"  [FAILED] Job {idx + 1}: {err}")
@@ -932,15 +934,17 @@ def batch(
     if failed_jobs:
         error(f"Failed to submit {len(failed_jobs)} jobs.")
 
-    # Print ordered mapping table so users can correlate operation IDs to commands
+    # Print ordered mapping table so users can correlate operation IDs to commands.
+    # Long commands are wrapped (overflow="fold") rather than truncated so the
+    # full command is always visible — this is the canonical correlation artifact.
     if successful_jobs:
         successful_jobs.sort(key=lambda t: t[0])
         table = Table(title="Operation Mapping (input order)")
-        table.add_column("#", justify="right", style="cyan")
-        table.add_column("Operation ID", style="green")
-        table.add_column("Command", style="white")
+        table.add_column("#", justify="right", style="cyan", no_wrap=True)
+        table.add_column("Operation ID", style="green", no_wrap=True)
+        table.add_column("Command", style="white", overflow="fold")
         for idx, op_id, cmd in successful_jobs:
-            table.add_row(str(idx + 1), op_id, cmd[:80])
+            table.add_row(str(idx + 1), op_id, cmd)
         Console().print(table)
 
     # Keep operation_ids list for any downstream callers

--- a/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_cli_commands.py
@@ -227,6 +227,62 @@ class TestBatchCommand:
 
         assert result.exit_code == 1
 
+    def test_batch_does_not_truncate_long_commands(self, monkeypatch):
+        """Long commands must appear in full in both the live progress line
+        and the final Operation Mapping table — never truncated.
+
+        Regression for the customer-reported issue where commands >80 chars
+        were silently sliced via ``cmd[:80]`` in both surfaces of
+        ``discovery job batch``.
+        """
+        # Force a wide Rich Console so the table cell doesn't fold the
+        # command across multiple lines (which would make a single
+        # contiguous substring assertion flaky). The live line uses
+        # ``overflow="ignore"`` and is unaffected by terminal width.
+        monkeypatch.setenv("COLUMNS", "500")
+
+        # 150-char command with two unique markers: one before the old
+        # 80-char truncation point and one well past it. Both must appear.
+        early_marker = "EARLY42X"
+        late_marker = "LATE99XY"
+        long_command = (
+            f"echo {early_marker} "
+            + ("x" * 100)
+            + f" {late_marker} done"
+        )
+        assert len(long_command) > 120
+        assert long_command.index(late_marker) > 80, "late marker must sit past old 80-char cutoff"
+
+        mock_cfg = MagicMock()
+        mock_cfg.project_name = "test-project"
+        mock_cfg.workspace_url = "https://example.com"
+        mock_cfg.tool_id = "tool-123"
+        mock_cfg.nodepool_id = "nodepool-123"
+        mock_cfg.datacontainer_id = "dc-123"
+
+        mock_response = MagicMock()
+        mock_response.id = "op-long-1"
+
+        with patch.object(cli_submit, "load_project_config", return_value=mock_cfg), \
+             patch.object(cli_submit, "load_tool_config"), \
+             patch.object(cli_submit, "ensure_datacontainer"), \
+             patch.object(cli_submit, "emit_env"), \
+             patch.object(cli_submit, "prepare_command", side_effect=lambda c, *a, **kw: c), \
+             patch.object(cli_submit, "get_azure_username", return_value="testuser"), \
+             patch.object(cli_submit, "start_tool_run", return_value=mock_response):
+            result = runner.invoke(app, ["job", "batch", "1", long_command])
+
+        assert result.exit_code == 0, result.output
+        # Mapping table should appear at all.
+        assert "Operation Mapping" in result.output
+        # Both markers — including the one past char 80 — must be present
+        # somewhere in the combined output (live line + final table).
+        assert early_marker in result.output
+        assert late_marker in result.output, (
+            "Long command was truncated before the late marker; "
+            "expected full command in batch output."
+        )
+
 
 # =============================================================================
 # VSCode Command Tests


### PR DESCRIPTION
Long commands with the differentiator at the end should be displayed in full to allow easier correlation with operation IDs.