### PR TITLE
Fix TLS trust for PubMed and CorePython tools (honor OS trust store, drop unverified-SSL workaround)

### DIFF
--- a/agents/core-python-agent/tools/corepython/Dockerfile
+++ b/agents/core-python-agent/tools/corepython/Dockerfile
@@ -51,6 +51,14 @@ RUN tdnf install -y --setopt=install_weak_deps=False \
       shadow-utils \
  && tdnf clean all
 
+# Make Python HTTP clients honor the OS trust store instead of conda's certifi bundle.
+# The conda `requests`/`urllib3` default to certifi and conda's OpenSSL uses the env's own CA
+# file; point them at the OS trust bundle so any CA added via update-ca-trust (e.g. a
+# TLS-inspecting egress CA supplied by the platform) is trusted by all HTTP clients.
+ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
 # Non-root user (SFI / CIS benchmark requirement)
 RUN groupadd -r moluser && useradd -r -g moluser -s /sbin/nologin moluser
 

--- a/agents/pubmed/tools/PubMed/Dockerfile
+++ b/agents/pubmed/tools/PubMed/Dockerfile
@@ -5,6 +5,14 @@ WORKDIR /app
 # Install CA certificates for HTTPS connectivity (required for VS Code tunnels)
 RUN tdnf install -y ca-certificates && update-ca-trust
 
+# Make Python HTTP clients honor the OS trust store instead of only certifi's bundle.
+# Bio.Entrez (urllib) already uses the OS store; requests/pymed default to certifi, so
+# point them at the OS trust bundle. Any CA added via update-ca-trust (e.g. a TLS-inspecting
+# egress CA supplied by the platform) is then trusted by all HTTP clients in this image.
+ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
 # Install PubMed/NCBI API access libraries
 RUN pip3 install biopython
 RUN pip3 install pymed

--- a/agents/pubmed/tools/PubMed/pubmed_utils.py
+++ b/agents/pubmed/tools/PubMed/pubmed_utils.py
@@ -18,18 +18,17 @@ Date: October 2025
 import json
 import os
 import time
-import ssl
 from typing import List, Dict, Optional, Any
 from xml.etree import ElementTree as ET
 
 from pymed import PubMed
 from Bio import Entrez
 
-# Configure SSL to handle certificate issues in containers
-try:
-    ssl._create_default_https_context = ssl._create_unverified_context
-except AttributeError:
-    pass
+# TLS certificate verification is intentionally left ENABLED.
+# In environments with TLS-inspecting egress, supply the inspecting CA to the
+# container's trust store (e.g. add it under /etc/pki/ca-trust/source/anchors and
+# run update-ca-trust, or set REQUESTS_CA_BUNDLE/SSL_CERT_FILE) rather than
+# disabling verification.
 
 
 class PubMedUtils:


### PR DESCRIPTION
## Problem

CogLoop tasks failed with `SSL CERTIFICATE_VERIFY_FAILED` when their tools called NCBI E-utilities. The tools run as jobs on the Discovery Supercomputer/Nodepool (AKS), whose egress performs TLS inspection and presents a private CA that `certifi` (and conda's bundled certs) do not trust.

## Changes

### PubMed tool (`agents/pubmed/tools/PubMed`)
- **Remove** the insecure `ssl._create_default_https_context = ssl._create_unverified_context` workaround. It only silently disabled verification for `urllib`/`Bio.Entrez` (insecure) and had no effect on `pymed`/`requests`, so the real failure persisted. Verification now stays **enabled** for all paths.
- **Dockerfile**: set `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE` / `CURL_CA_BUNDLE` to the OS trust bundle so `requests`/`pymed` honor CAs added via `update-ca-trust`.

### CorePython tool (`agents/core-python-agent/tools/corepython`)
- **Dockerfile**: point the same env vars at the OS trust bundle. The conda `requests`/`urllib3` default to certifi and conda's OpenSSL uses the env CA file, so a platform-added egress CA was not honored. No code change — the tool has no verification workaround.

In both tools, no environment-specific CA is baked into the image; the platform supplies the egress CA via the OS trust store.

## Validation

Reproduced and validated locally inside each real tool image using a mitmproxy TLS-interception harness (`requests` + `Bio.Entrez`; PubMed also via `pymed`):

| Scenario | requests / pymed | Bio.Entrez |
|---|---|---|
| Clean egress | ✅ | ✅ |
| Interception, CA **not** trusted | ❌ fails loudly (`CERTIFICATE_VERIFY_FAILED`) | ❌ fails loudly |
| Interception, CA added to OS store (`update-ca-trust`) | ✅ | ✅ |

- Clean egress: no regression.
- Untrusted interception: both HTTP paths now fail **visibly** instead of silently running unverified (security improvement; for PubMed this restores verification on the previously-masked Entrez path).
- Trusted interception: both paths succeed via the OS trust store alone — the intended fix.

Also manually validated both the tools on Discovery Enterprise both using CogLoop and the normal agent queries

## Notes

- No functional/API change to either tool; behavior change is limited to TLS trust handling.
- For TLS-inspecting environments, supply the inspecting CA to the container trust store (anchor + `update-ca-trust`) rather than disabling verification.
