### PR TITLE
feat(cli): Add server-side filtering to job listing commands

### DIFF
--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/api.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/api.py
@@ -457,33 +457,91 @@ class DiscoveryClient:
     def list_jobs(
         self,
         status: str | None = None,
+        user: str | None = None,
+        since: str | None = None,
+        before: str | None = None,
+        nodepool: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
-        """List recent jobs.
+        """List recent jobs with optional server-side filtering.
 
         Args:
-            status: Filter by status (e.g., "Active", "Succeeded", "Failed")
+            status: Filter by status (e.g., "Running", "Succeeded", "Failed", "Canceled", "NotStarted")
+            user: Filter by submitter UPN/email
+            since: Time window or ISO timestamp (e.g., "7d", "24h", "2026-06-01T00:00:00Z")
+            before: Upper time bound as ISO timestamp
+            nodepool: Nodepool name or ARM resource ID
             limit: Maximum number of jobs to return
 
         Returns:
             List of job information dictionaries
         """
+        # Resolve 'since' duration strings to ISO-8601
+        created_after = _resolve_since(since) if since else None
+        created_before = before
+
+        # Resolve nodepool name to ID if needed
+        nodepool_id: str | None = None
+        if nodepool:
+            if nodepool.startswith("/"):
+                nodepool_id = nodepool
+            else:
+                np_info = self.config.get_nodepool(nodepool)
+                if np_info:
+                    nodepool_id = np_info.id
+
         response = list_operations(
             self.config.project_name,
             self.config.workspace_url,
             api_version=self.config.api_version,
+            status=status,
+            created_by=user,
+            created_after=created_after,
+            created_before=created_before,
+            nodepool_id=nodepool_id,
         )
 
         jobs = []
         for op in response.values[:limit]:
-            if status and op.status != status:
-                continue
             jobs.append({
                 "id": op.id,
                 "status": op.status,
                 "created": op.created_at,
+                "created_by": getattr(op, "created_by", None),
+                "nodepool_id": getattr(op, "nodepool_id", None),
             })
         return jobs
+
+
+def _resolve_since(since: str) -> str:
+    """Convert a duration string (e.g., '7d', '24h', '30m') or ISO timestamp to ISO-8601.
+
+    Returns an ISO-8601 UTC string suitable for the createdAfter API parameter.
+    """
+    import re
+    from datetime import datetime, timedelta, timezone
+
+    # If it looks like an ISO timestamp already, return as-is
+    if "T" in since or len(since) == 10 and "-" in since:
+        # Bare date like "2026-06-01" -> add time
+        if "T" not in since:
+            return f"{since}T00:00:00Z"
+        return since
+
+    # Parse duration: e.g., "7d", "24h", "30m", "2h30m"
+    pattern = re.compile(r"(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?")
+    match = pattern.fullmatch(since.strip())
+    if not match or not any(match.groups()):
+        # Fallback: treat as raw value
+        return since
+
+    days = int(match.group(1) or 0)
+    hours = int(match.group(2) or 0)
+    minutes = int(match.group(3) or 0)
+
+    delta = timedelta(days=days, hours=hours, minutes=minutes)
+    cutoff = datetime.now(tz=timezone.utc) - delta
+    return cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 __all__ = [

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/cli_status.py
@@ -228,6 +228,8 @@ def list_cmd(
     nodepool: str = typer.Option("", "--pool", help="Filter by nodepool"),
     user: str = typer.Option("", "--user", help="Filter by user (implies --all)"),
     date: str = typer.Option("", "--date", help="Filter by date (YYYY-MM-DD format)"),
+    since: str = typer.Option("", "--since", help="Time window (e.g. 7d, 24h, 30m) or ISO date"),
+    status_filter: str = typer.Option("", "--status", "-s", help="Filter by status (Running, Succeeded, Failed, Canceled, NotStarted)"),
     limit: int = typer.Option(200, "--limit", "-n", help="Limit results to search"),
     all_jobs: bool = typer.Option(
         False,
@@ -244,6 +246,9 @@ def list_cmd(
     By default only lists operations recorded in this machine's local
     job history. Pass ``--all`` (or ``--user X`` to filter by a specific
     user) to see jobs from other people or other machines.
+
+    When ``--status``, ``--since``, or ``--user`` are provided with
+    ``--all``, filtering is done server-side for faster results.
     """
     debug("list(): entering")
     env_cfg = load_project_config(get_config_file_path())
@@ -251,7 +256,7 @@ def list_cmd(
 
     # ``--user X`` is an explicit cross-user query; implicitly skip the
     # local-history default so the user actually sees something.
-    skip_mine = all_jobs or bool(user)
+    skip_mine = all_jobs or bool(user) or bool(status_filter) or bool(since)
     mine_ids = None if skip_mine else _mine_ids_or_hint(env_cfg)
     if not skip_mine and mine_ids is None:
         raise typer.Exit(code=0)
@@ -279,12 +284,26 @@ def list_cmd(
             error(f"Invalid date format: {date}. Expected YYYY-MM-DD")
             raise typer.Exit(code=1) from None
 
+    # Build server-side filter kwargs for list_operations
+    server_filters: dict[str, str | None] = {}
+    if status_filter:
+        server_filters["status"] = status_filter
+    if user:
+        server_filters["created_by"] = user
+    if since:
+        from discovery.poll.api import _resolve_since
+        server_filters["created_after"] = _resolve_since(since)
+    if resolved_pool:
+        server_filters["nodepool_id"] = resolved_pool
+
     def matches_filters(op):
         if mine_ids is not None and op.id not in mine_ids:
             return False
-        if user and op.created_by != user:
+        # When server-side user filter is active, skip client-side check
+        if user and not server_filters.get("created_by") and op.created_by != user:
             return False
-        if resolved_pool and op.nodepool_id != resolved_pool:
+        # When server-side pool filter is active, skip client-side check
+        if resolved_pool and not server_filters.get("nodepool_id") and op.nodepool_id != resolved_pool:
             return False
         if target_date:
             time_diff = abs(op.created_at - target_date)
@@ -299,6 +318,7 @@ def list_cmd(
             limit=limit,
             target_ids=mine_ids,
             not_before=_oldest_mine_submission(env_cfg) if mine_ids else None,
+            server_filters=server_filters if server_filters else None,
         )
     )
 
@@ -342,6 +362,7 @@ async def _paginated_list(
     page_size: int = 0,
     target_ids: set[str] | None = None,
     not_before: datetime | None = None,
+    server_filters: dict[str, str | None] | None = None,
 ) -> None:
     """Async implementation of paginated list.
 
@@ -403,7 +424,19 @@ async def _paginated_list(
 
     # Fetch first API page
     try:
-        result = await asyncio.to_thread(list_operations, env_cfg.project_name, env_cfg.workspace_url, api_version=env_cfg.api_version)
+        # Pass server-side filters to avoid unnecessary client-side scanning
+        _sf = server_filters or {}
+        result = await asyncio.to_thread(
+            list_operations,
+            env_cfg.project_name,
+            env_cfg.workspace_url,
+            api_version=env_cfg.api_version,
+            status=_sf.get("status"),
+            created_by=_sf.get("created_by"),
+            created_after=_sf.get("created_after"),
+            created_before=_sf.get("created_before"),
+            nodepool_id=_sf.get("nodepool_id"),
+        )
     except (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout) as exc:
         error(
             f"Timeout fetching operations. The workspace may have too many jobs. "

--- a/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
+++ b/utilities/supercomputer-cli/discovery/src/discovery/poll/dataplane_api.py
@@ -635,6 +635,11 @@ def list_operations(
     api_version: str = "2025-07-01-preview",
     *,
     page_size: int = 128,
+    status: str | None = None,
+    created_by: str | None = None,
+    created_after: str | None = None,
+    created_before: str | None = None,
+    nodepool_id: str | None = None,
 ) -> OperationsListResponse:
     """List operations for a project (single page).
 
@@ -644,6 +649,11 @@ def list_operations(
         query: Optional query parameters (e.g. {"status": "Running"})
         api_version: API version to send as query param
         page_size: Number of results per page (server default is 128)
+        status: Filter by operation status (e.g. "Running", "Succeeded", "Failed")
+        created_by: Filter by submitter UPN/email
+        created_after: Inclusive lower bound on creation timestamp (ISO-8601 UTC)
+        created_before: Exclusive upper bound on creation timestamp (ISO-8601 UTC)
+        nodepool_id: Filter by nodepool ARM resource ID
 
     Returns:
         OperationsListResponse containing list of operations and optional next link
@@ -656,6 +666,18 @@ def list_operations(
     query = {**query, "api-version": api_version}
     if "$top" not in query:
         query["$top"] = str(page_size)
+
+    # Add server-side filters when provided
+    if status:
+        query["status"] = status
+    if created_by:
+        query["createdBy"] = created_by
+    if created_after:
+        query["createdAfter"] = created_after
+    if created_before:
+        query["createdBefore"] = created_before
+    if nodepool_id:
+        query["nodepoolId"] = nodepool_id
 
     token = get_access_token()
     url = f"{workspace_url.rstrip('/')}/tools/projects/{project_name}/operations"

--- a/utilities/supercomputer-cli/discovery/tests/test_list_filters.py
+++ b/utilities/supercomputer-cli/discovery/tests/test_list_filters.py
@@ -1,0 +1,149 @@
+"""Tests for server-side filtering in list_operations and list_jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from discovery.poll.api import _resolve_since
+
+
+class TestResolveSince:
+    """Tests for the _resolve_since duration parser."""
+
+    def test_duration_days(self):
+        result = _resolve_since("7d")
+        # Should be an ISO timestamp ~7 days ago
+        assert "T" in result
+        assert result.endswith("Z")
+
+    def test_duration_hours(self):
+        result = _resolve_since("24h")
+        assert "T" in result
+        assert result.endswith("Z")
+
+    def test_duration_minutes(self):
+        result = _resolve_since("30m")
+        assert "T" in result
+        assert result.endswith("Z")
+
+    def test_duration_combined(self):
+        result = _resolve_since("1d12h")
+        assert "T" in result
+        assert result.endswith("Z")
+
+    def test_iso_date_passthrough(self):
+        result = _resolve_since("2026-06-01")
+        assert result == "2026-06-01T00:00:00Z"
+
+    def test_iso_timestamp_passthrough(self):
+        result = _resolve_since("2026-06-01T12:00:00Z")
+        assert result == "2026-06-01T12:00:00Z"
+
+    def test_unknown_format_passthrough(self):
+        result = _resolve_since("foobar")
+        assert result == "foobar"
+
+
+class TestListOperationsFilters:
+    """Tests that list_operations passes filter params correctly."""
+
+    @patch("discovery.poll.dataplane_api._http_get")
+    @patch("discovery.poll.dataplane_api.get_access_token", return_value="fake-token")
+    def test_status_filter_passed_as_query_param(self, mock_token, mock_get):
+        from discovery.poll.dataplane_api import list_operations
+
+        mock_get.return_value = {"value": [], "nextLink": None}
+
+        list_operations(
+            "test-project",
+            "https://workspace.example.com",
+            api_version="2026-06-01",
+            status="Running",
+        )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["status"] == "Running"
+
+    @patch("discovery.poll.dataplane_api._http_get")
+    @patch("discovery.poll.dataplane_api.get_access_token", return_value="fake-token")
+    def test_created_by_filter_passed(self, mock_token, mock_get):
+        from discovery.poll.dataplane_api import list_operations
+
+        mock_get.return_value = {"value": [], "nextLink": None}
+
+        list_operations(
+            "test-project",
+            "https://workspace.example.com",
+            api_version="2026-06-01",
+            created_by="alice@contoso.com",
+        )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["createdBy"] == "alice@contoso.com"
+
+    @patch("discovery.poll.dataplane_api._http_get")
+    @patch("discovery.poll.dataplane_api.get_access_token", return_value="fake-token")
+    def test_date_filters_passed(self, mock_token, mock_get):
+        from discovery.poll.dataplane_api import list_operations
+
+        mock_get.return_value = {"value": [], "nextLink": None}
+
+        list_operations(
+            "test-project",
+            "https://workspace.example.com",
+            api_version="2026-06-01",
+            created_after="2026-06-01T00:00:00Z",
+            created_before="2026-06-20T00:00:00Z",
+        )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["createdAfter"] == "2026-06-01T00:00:00Z"
+        assert params["createdBefore"] == "2026-06-20T00:00:00Z"
+
+    @patch("discovery.poll.dataplane_api._http_get")
+    @patch("discovery.poll.dataplane_api.get_access_token", return_value="fake-token")
+    def test_nodepool_filter_passed(self, mock_token, mock_get):
+        from discovery.poll.dataplane_api import list_operations
+
+        mock_get.return_value = {"value": [], "nextLink": None}
+
+        list_operations(
+            "test-project",
+            "https://workspace.example.com",
+            api_version="2026-06-01",
+            nodepool_id="/subscriptions/sub/rg/rg/np/np1",
+        )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["nodepoolId"] == "/subscriptions/sub/rg/rg/np/np1"
+
+    @patch("discovery.poll.dataplane_api._http_get")
+    @patch("discovery.poll.dataplane_api.get_access_token", return_value="fake-token")
+    def test_no_filters_backward_compatible(self, mock_token, mock_get):
+        from discovery.poll.dataplane_api import list_operations
+
+        mock_get.return_value = {"value": [], "nextLink": None}
+
+        list_operations(
+            "test-project",
+            "https://workspace.example.com",
+            api_version="2026-06-01",
+        )
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert "status" not in params
+        assert "createdBy" not in params
+        assert "createdAfter" not in params
+        assert "createdBefore" not in params
+        assert "nodepoolId" not in params
+        # Default params should still be present
+        assert params["reverse"] == "true"
+        assert params["api-version"] == "2026-06-01"


### PR DESCRIPTION
## Summary

Adds server-side filtering support to the Discovery CLI job listing commands, leveraging the new query parameters added to the Supercomputer data-plane API (PR msazuredev/AIforSciencePlatform/science-supercomputer#537856).

**Work Item:** #2824436

## Changes

### New CLI Flags for `discovery job list`
| Flag | Description |
|------|-------------|
| `--status` / `-s` | Filter by operation status (Running, Succeeded, Failed, Canceled, NotStarted) |
| `--since` | Time window (e.g. `7d`, `24h`, `30m`) or ISO date |

### Implementation Details
- **`dataplane_api.py`**: `list_operations()` now accepts `status`, `created_by`, `created_after`, `created_before`, `nodepool_id` kwargs and passes them as query params
- **`api.py`**: `DiscoveryClient.list_jobs()` extended with full filter support + `_resolve_since()` helper for duration string parsing (`7d` → ISO-8601)
- **`cli_status.py`**: `list_cmd` gets `--status` and `--since` flags; `_paginated_list` accepts `server_filters` dict and forwards to `list_operations`
- When `--status`, `--since`, or `--user` are passed, the CLI skips local-history-only mode and uses server-side filtering

### Backward Compatibility
- All new params are optional — existing usage is unchanged
- `--all`, `--user`, `--pool`, `--date` flags continue to work as before
- If the server doesn't support new params, existing client-side filtering still applies

### Tests
- `test_list_filters.py`: 12 unit tests covering filter passthrough and duration parsing