### PR TITLE
docs: bump download section to v0.15.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
       <a href="https://aka.ms/downloads/arm64/current"><strong>Arm64</strong></a>
     </td>
     <td valign="middle">
-      A self-contained Windows app - no SDK, no cloud setup. Current release: <strong>v0.15.4</strong>.<br>
+      A self-contained Windows app - no SDK, no cloud setup. Current release: <strong>v0.15.5</strong>.<br>
       <sub>macOS and Linux are not supported yet. Windows x64 and Windows ARM64 installers are available today.</sub><br><br>
       🛠️ <a href="docs/discovery-app/install.md">Install guide</a> - setup, verification, and upgrade steps.
     </td>
@@ -21,7 +21,7 @@
 
 | Version | Date | Platform | Installer |
 | --- | --- | --- | --- |
-| v0.15.3 _(previous)_ | 2026-06-22 | Windows x64 | [`Discovery-app-0.15.3-preview-win-x64.exe`](https://aka.ms/discovery/download/previous) |
+| v0.15.4 _(previous)_ | 2026-06-29 | Windows x64 | [`Discovery-app-0.15.4-preview-win-x64.exe`](https://aka.ms/discovery/download/previous) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
       <a href="https://aka.ms/discovery/download/current"><img src="includes/media/windows-download-card.svg" width="220" height="80" alt="Download Windows 11"></a><br>
       <strong>User Installer</strong>
       <a href="https://aka.ms/discovery/download/current"><strong>x64</strong></a>
-      <a href="https://aka.ms/downloads/arm64/current"><strong>Arm64</strong></a>
+      <a href="https://aka.ms/discovery/download/arm64/current"><strong>Arm64</strong></a>
     </td>
     <td valign="middle">
       A self-contained Windows app - no SDK, no cloud setup. Current release: <strong>v0.15.5</strong>.<br>
@@ -22,6 +22,7 @@
 | Version | Date | Platform | Installer |
 | --- | --- | --- | --- |
 | v0.15.4 _(previous)_ | 2026-06-29 | Windows x64 | [`Discovery-app-0.15.4-preview-win-x64.exe`](https://aka.ms/discovery/download/previous) |
+| v0.15.4 _(previous)_ | 2026-06-29 | Windows Arm64 | [`Discovery-app-0.15.4-preview-win-arm64.exe`](https://aka.ms/discovery/download/arm64/previous) |
 
 ---
 


### PR DESCRIPTION
Updates the **Download the Discovery app** section of the README:

- Current release: v0.15.4 -> **v0.15.5**
- Previous release table: rolled to **v0.15.4** (2026-06-29), with installer link name updated accordingly

This keeps the section aligned with the `current + immediately preceding` release policy.