### PR TITLE
Fix corepython tool compute: add storage/gpu + RAM units so it dispatches JobSets

### DIFF
--- a/agents/core-python-agent/tools/corepython/tool.yaml
+++ b/agents/core-python-agent/tools/corepython/tool.yaml
@@ -19,7 +19,7 @@ infra:
         gpu: 0
       max_resources:
         cpu: 2
-        ram: 16Gi
+        ram: 13Gi
         storage: 32Gi
         gpu: 0
       infiniband: false

--- a/agents/core-python-agent/tools/corepython/tool.yaml
+++ b/agents/core-python-agent/tools/corepython/tool.yaml
@@ -14,10 +14,14 @@ infra:
     compute:
       min_resources:
         cpu: 1
-        ram: 8
+        ram: 8Gi
+        storage: 8Gi
+        gpu: 0
       max_resources:
         cpu: 2
-        ram: 16
+        ram: 16Gi
+        storage: 32Gi
+        gpu: 0
       infiniband: false
       recommended_sku:
         - Standard_D4s_v6


### PR DESCRIPTION
## What & why

`corepython` is the only tool in the catalog whose `compute` block was authored differently from every working tool, and the difference prevented it from ever executing:

- `ram` was a **bare integer** (`8` / `16`) instead of a quantity string (`8Gi` / `16Gi`). A bare `8` is interpreted as **8 bytes**, not 8 GiB.
- `min_resources` / `max_resources` **omitted `storage`** (and `gpu`) entirely.

With no `storage` quantity, the platform accepted the tool run (`TaskAccepted`) but **never created a JobSet** on the supercomputer. The run then timed out after ~7.8 min with `"<no logs found>"`, and the bound agent fabricated an answer instead of executing code.

Every tool that dispatches correctly (e.g. `pubchem`, `aizynthfinder`) includes `storage` + `gpu: 0` and uses `Gi` RAM units. This PR brings `corepython` in line.

## The change

```diff
       min_resources:
         cpu: 1
-        ram: 8
+        ram: 8Gi
+        storage: 8Gi
+        gpu: 0
       max_resources:
         cpu: 2
-        ram: 16
+        ram: 16Gi
+        storage: 32Gi
+        gpu: 0
```

(`agents/core-python-agent/tools/corepython/tool.yaml`)

## Verification (live)

Applied the equivalent change to a deployed `corepython` and exercised it through a bound agent:

- Agent dispatched `corepython` → **JobSet created** → pod scheduled on the node pool → **Completed in ~61 s**.
- Real result returned and relayed verbatim (no fabrication): sample stdev / mean of a 10‑element list (`Mean: 12.91`, `Sample standard deviation: 1.0857153299911437`).

Before the change the identical run produced no JobSet and timed out as `"<no logs found>"`.

## Related platform recommendation (separate)

The tool run should be **rejected at submit time** with a validation error when a container tool's `compute` omits `storage`, rather than silently producing no JobSet and letting the run time out as `"<no logs found>"`. The silent failure is what made this hard to diagnose. Filing that separately against the service.
