### PR TITLE
Pipeline for release notes and release widget

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,161 @@
+# Release refresh automation
+
+Three workflows work together to keep the mutable `current` tag, the
+`Discovery-app-preview-release` GitHub Release, and the download table in
+[`README.md`](../../README.md) in sync with the app that ships behind the
+`aka.ms/discovery/download/*` short links. The homepage "Releases" sidebar
+displays `published_at`, so the point of this automation is to keep that
+timestamp fresh — the previous rolling release was showing "2 months ago"
+even after the tag had been moved forward.
+
+## The pieces
+
+| Workflow | Purpose | Triggers |
+| --- | --- | --- |
+| [`refresh-current.yml`](refresh-current.yml) | Moves the `current` git tag to `main` HEAD, delete-and-recreates the `current` GitHub Release (fresh `published_at`, auto-generated notes), and opens a PR that bumps the README download table. | `workflow_dispatch` (manual button) + `repository_dispatch` (`event_type: app-released`) |
+| [`probe-aka-ms.yml`](probe-aka-ms.yml) | Every 30 minutes, follows the aka.ms redirects, compares the resolved version to the version recorded in README, and calls `refresh-current.yml` when they drift. | `schedule` (`*/30 * * * *`) + `workflow_dispatch` |
+| ADO release pipeline task (future) | Same effect as the probe but event-driven — internal build POSTs `repository_dispatch` to GitHub the moment a new app ships. Draft PowerShell snippet lives in the chat history for this branch; ADO owners can adopt it when they're ready. Requires a GitHub App (recommended) or workload identity federation, per the [1ES PAT removal case study](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-security-configuration/configuration-guides/case-studies/azureauth-removing-pats). | `repository_dispatch` |
+
+Both trigger paths funnel into the same worker (`refresh-current.yml`), so
+adding the ADO event trigger later is additive — no changes to the poll
+workflow are required.
+
+## Release asset policy
+
+The release refresh must not upload installer files or any other custom
+assets to the GitHub Release. Download links remain the stable `aka.ms`
+redirects in the root README; release automation must not call `gh release
+upload` or use an upload-asset action.
+
+GitHub automatically displays `Source code (zip)` and `Source code (tar.gz)`
+for every release backed by a git tag. Those two generated links cannot be
+removed independently while `current` remains a tag-backed release. They are
+not uploaded assets and do not contain the Windows installer binaries.
+
+## How the probe knows a new version shipped
+
+`aka.ms/discovery/download/current` 301-redirects to a versioned filename on
+Azure Front Door:
+
+```text
+$ curl -sI https://aka.ms/discovery/download/current
+HTTP/1.1 301 Moved Permanently
+Location: https://.../discoveryexpress/Discovery-app-0.15.12-preview-win-x64.exe
+```
+
+The probe:
+
+1. Reads `Current release: <strong>vX.Y.Z</strong>` from `README.md`.
+2. Extracts `X.Y.Z` from the `Location` header on both the `current` and
+   `previous` aka.ms redirects.
+3. HEADs the `previous` target blob and reads its `Last-Modified` header to
+   derive the `previous_date` column.
+4. If the aka.ms `current` version differs from the README `current`
+   version — **and** no `release/refresh-current-vX.Y.Z` branch already
+   exists on the remote (debounce) — it calls `gh workflow run
+   refresh-current.yml` with the three parsed inputs.
+
+## Manual trigger
+
+You can always run either workflow by hand from the
+[Actions tab](https://github.com/microsoft/discovery/actions):
+
+- **Refresh current release** — fill in `version`, `previous_version`,
+  `previous_date` when you want to force the retag + rerelease + README PR
+  regardless of what aka.ms says.
+- **Probe aka.ms Discovery download** — runs the poll immediately without
+  waiting for the next 30-minute schedule tick.
+
+## Local test helpers
+
+Two PowerShell scripts mirror the workflow's runtime logic so you can validate
+regex/parsing changes from your workstation before pushing:
+
+- [`scripts/test-probe-aka-ms.ps1`](../../scripts/test-probe-aka-ms.ps1) — hits
+  the live `aka.ms/discovery/download/{current,previous}` endpoints and
+  replays the probe's decision matrix against your local `README.md`.
+- [`scripts/test-refresh-current-readme.ps1`](../../scripts/test-refresh-current-readme.ps1) —
+  runs the exact regex substitutions from the worker's "Patch README.md"
+  step against a copy of `README.md` and prints the resulting `git diff` so
+  you can preview the PR contents.
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-probe-aka-ms.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-refresh-current-readme.ps1 `
+    -NewVersion v0.15.13 -PreviousVersion v0.15.12 -PreviousDate 2026-08-28
+```
+
+Sample probe output:
+
+```text
+aka.ms current  -> v0.15.12
+aka.ms previous -> v0.15.11
+README current  -> v0.15.12
+previous Last-Modified header -> Tue, 18 Aug 2026 13:24:38 GMT
+previous_date -> 2026-08-18
+
+DECISION: no-op (README already at v0.15.12)
+```
+
+## Dry-run mode for CI smoke tests
+
+Both workflows accept a `dry_run` boolean input on `workflow_dispatch`. When
+`true`, they perform every read-only step (probe, notes generation, README
+patch in the workspace) but skip everything that mutates external state:
+
+| Step (worker) | dry-run behaviour |
+| --- | --- |
+| Move `current` tag | Skipped; prints what the retag would do. |
+| Delete + recreate `current` release | Skipped; prints the notes preview. |
+| Patch `README.md` in workspace | Runs (nothing pushed). |
+| Push branch + open PR | Skipped; prints the branch name and PR title. |
+
+The probe skips the final `gh workflow run refresh-current.yml` call and
+prints the exact command it would have issued.
+
+Recommended first-run smoke test after this branch merges to `main`:
+
+1. Actions → **Refresh current release** → *Run workflow*.
+2. Fill in the same `version` / `previous_version` / `previous_date` the
+   README already has, tick `dry_run: true`, and run. Verify the logs show
+   the retag + rerelease + PR-open steps as `[dry-run] would run: ...`.
+3. Actions → **Probe aka.ms Discovery download** → *Run workflow* with
+   `dry_run: true`. Verify the decision line matches
+   `DECISION: no-op` (or `[dry-run] would run: gh workflow run …` if a new
+   release has just shipped).
+4. Once both dry-runs look clean, the scheduled probe will start firing on
+   its 30-minute cron and the worker will act on real inputs.
+
+## Permissions
+
+- `refresh-current.yml` needs `contents: write` (retag, edit release, push
+  branch), `pull-requests: write` (open the README PR), and `issues: write`
+  (for the failure tracking issue). Uses `secrets.GITHUB_TOKEN`.
+- `probe-aka-ms.yml` needs `actions: write` (call `gh workflow run`),
+  `contents: read` (read `README.md`), and `issues: write` (for the failure
+  tracking issue). No cross-boundary credentials.
+
+## Failure reporting
+
+Both workflows have a `report-failure` job that runs only `if: failure()`.
+When any earlier job fails, it opens (or comments on) a GitHub issue
+labelled [`release-automation`](https://github.com/microsoft/discovery/labels/release-automation)
+with a link to the failing run, the event that triggered it, and a checklist
+for triage.
+
+- The label is created idempotently on first failure with color `#d73a4a`.
+- Deduplication: if an open issue with title `[release-automation] <workflow>
+  failed` already exists, the job comments on it rather than opening a new
+  one. Close the issue once you've reconciled state to reset the cycle.
+- Fires for **any** failure — parser drift (aka.ms URL format changed),
+  README regex miss, broken aka.ms link (the worker HEADs every download
+  URL after patching), retag/rerelease failure, PR-open failure, or the
+  `gh workflow run` dispatch call failing.
+
+## Link verification
+
+Before the worker opens the README PR, it enumerates every
+`https://aka.ms/discovery/download/...` URL in `README.md` and HEADs each
+one. The job fails (which triggers `report-failure`) if any URL returns
+anything other than a 3xx with a non-empty `Location` header. This catches
+upstream aka.ms breakage before a stale/broken README lands on `main`.

--- a/.github/workflows/probe-aka-ms.yml
+++ b/.github/workflows/probe-aka-ms.yml
@@ -12,7 +12,7 @@ name: Probe aka.ms Discovery download
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/probe-aka-ms.yml
+++ b/.github/workflows/probe-aka-ms.yml
@@ -1,0 +1,236 @@
+name: Probe aka.ms Discovery download
+
+# Poll aka.ms/discovery/download/{current,previous} for changes. When the
+# `current` redirect points at a version that differs from the version
+# currently recorded in README.md, dispatch refresh-current.yml with the
+# three parsed inputs (version, previous_version, previous_date).
+#
+# This is a poll-based fallback for the future Approach A pattern where the
+# internal ADO release pipeline dispatches refresh-current.yml directly via
+# repository_dispatch. Both paths funnel into the same worker workflow, so
+# adding the event trigger later is additive.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Probe and log what would be dispatched, but don't call refresh-current.yml."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: probe-aka-ms
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Compare aka.ms against README and dispatch if drifted
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CURRENT_URL:  https://aka.ms/discovery/download/current
+      PREVIOUS_URL: https://aka.ms/discovery/download/previous
+
+    steps:
+      - name: Checkout main (README only)
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: main
+          sparse-checkout: |
+            README.md
+          sparse-checkout-cone-mode: false
+
+      - name: Determine effective dry_run
+        id: mode
+        env:
+          # inputs.dry_run is only populated on workflow_dispatch; empty for schedule/repository_dispatch.
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [[ "${DRY_RUN_INPUT:-false}" == "true" ]]; then
+            echo "dry_run=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Probe aka.ms and decide
+        id: probe
+        run: |
+          set -euo pipefail
+
+          # 1. Version currently recorded in README.
+          readme_current="$(grep -oE 'Current release:[[:space:]]*<strong>v[0-9]+\.[0-9]+\.[0-9]+</strong>' README.md \
+            | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' \
+            | head -n1 || true)"
+          if [[ -z "${readme_current}" ]]; then
+            echo "::error::Could not parse 'Current release: <strong>vX.Y.Z</strong>' from README.md"
+            exit 1
+          fi
+          echo "README current: ${readme_current}"
+
+          # 2. Resolve one aka.ms redirect and return "vX.Y.Z<TAB>target_url".
+          #    curl 8.3+ supports %header{location}, which sidesteps parsing
+          #    the raw HEAD response and is immune to console line-wrap.
+          resolve() {
+            local url="$1" target ver
+            target="$(curl -sI -o /dev/null -w '%header{location}' "${url}")"
+            if [[ -z "${target}" ]]; then
+              echo "::error::No Location header on ${url}" >&2
+              return 1
+            fi
+            ver="$(printf '%s' "${target}" \
+              | grep -oE 'Discovery-app-[0-9]+\.[0-9]+\.[0-9]+-preview-win-x64\.exe' \
+              | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
+              | head -n1 || true)"
+            if [[ -z "${ver}" ]]; then
+              echo "::error::Could not parse version from redirect target: ${target}" >&2
+              return 1
+            fi
+            printf 'v%s\t%s' "${ver}" "${target}"
+          }
+
+          IFS=$'\t' read -r aka_current  _                 < <(resolve "${CURRENT_URL}")
+          IFS=$'\t' read -r aka_previous previous_target   < <(resolve "${PREVIOUS_URL}")
+          echo "aka.ms current:  ${aka_current}"
+          echo "aka.ms previous: ${aka_previous}"
+          echo "aka.ms previous target: ${previous_target}"
+
+          # 3. Already in sync — nothing to do.
+          if [[ "${aka_current}" == "${readme_current}" ]]; then
+            echo "No change: README already at ${readme_current}."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 4. Sanity guard: refuse to fire if both aka.ms links resolve to the
+          #    same version — that's a transient state during an aka.ms edit
+          #    and would blow away the 'previous' row with a duplicate entry.
+          if [[ "${aka_current}" == "${aka_previous}" ]]; then
+            echo "::warning::aka.ms /current and /previous both resolve to ${aka_current}. Deferring."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 5. Debounce: if refresh-current has already opened a PR for this
+          #    version, don't stack a second dispatch on top of it.
+          branch="release/refresh-current-${aka_current}"
+          if git ls-remote --exit-code --heads \
+               "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+               "${branch}" >/dev/null 2>&1; then
+            echo "Refresh branch ${branch} already exists on origin — refresh already dispatched."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 6. previous_date from the previous blob's Last-Modified.
+          prev_last_mod="$(curl -sI -o /dev/null -w '%header{last-modified}' "${previous_target}")"
+          if [[ -z "${prev_last_mod}" ]]; then
+            echo "::warning::No Last-Modified on previous blob; falling back to today's UTC date."
+            prev_date="$(date -u +%F)"
+          else
+            prev_date="$(date -u -d "${prev_last_mod}" +%F)"
+          fi
+          echo "previous_date: ${prev_date}"
+
+          {
+            echo "changed=true"
+            echo "version=${aka_current}"
+            echo "previous_version=${aka_previous}"
+            echo "previous_date=${prev_date}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch refresh-current.yml
+        if: steps.probe.outputs.changed == 'true' && steps.mode.outputs.dry_run != 'true'
+        env:
+          VERSION:          ${{ steps.probe.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.probe.outputs.previous_version }}
+          PREVIOUS_DATE:    ${{ steps.probe.outputs.previous_date }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching refresh-current.yml: version=${VERSION}, previous_version=${PREVIOUS_VERSION}, previous_date=${PREVIOUS_DATE}"
+          gh workflow run refresh-current.yml \
+            --ref main \
+            -f version="${VERSION}" \
+            -f previous_version="${PREVIOUS_VERSION}" \
+            -f previous_date="${PREVIOUS_DATE}"
+
+      - name: Dry-run — would dispatch
+        if: steps.probe.outputs.changed == 'true' && steps.mode.outputs.dry_run == 'true'
+        env:
+          VERSION:          ${{ steps.probe.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.probe.outputs.previous_version }}
+          PREVIOUS_DATE:    ${{ steps.probe.outputs.previous_date }}
+        run: |
+          echo "::notice::[dry-run] would run: gh workflow run refresh-current.yml --ref main -f version=${VERSION} -f previous_version=${PREVIOUS_VERSION} -f previous_date=${PREVIOUS_DATE}"
+
+  report-failure:
+    name: Open/update tracking issue on failure
+    needs: probe
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Ensure label exists
+        run: |
+          gh label create release-automation \
+            --repo "${GITHUB_REPOSITORY}" \
+            --color "d73a4a" \
+            --description "Automated release refresh workflow failures" \
+            2>/dev/null || true
+
+      - name: Create or update tracking issue
+        env:
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT:    ${{ github.event_name }}
+          ACTOR:    ${{ github.actor }}
+          SHA:      ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          title="[release-automation] ${WORKFLOW} failed"
+          body_file="$(mktemp)"
+          {
+            echo "Automated release-refresh workflow **${WORKFLOW}** failed."
+            echo
+            echo "- Run: ${RUN_URL}"
+            echo "- Event: \`${EVENT}\`"
+            echo "- Actor: @${ACTOR}"
+            echo "- SHA: \`${SHA}\`"
+            echo
+            echo "The rolling \`current\` GitHub Release and README download table may now be out of sync with the aka.ms redirect. Please:"
+            echo
+            echo "1. Inspect the run log at the URL above and identify the failed step."
+            echo "2. Fix the underlying issue (transient aka.ms edit, broken CDN, README regex drift, credential rotation, etc.)."
+            echo "3. Re-run the workflow manually from the Actions tab. Consider \`dry_run: true\` first to smoke-test the fix."
+            echo "4. Verify the \`current\` tag, GitHub Release, and README download table match the shipped app version, then close this issue."
+          } > "${body_file}"
+
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
+            --state open --label release-automation \
+            --search "${title} in:title" \
+            --json number --jq '.[0].number' 2>/dev/null || true)"
+
+          if [[ -n "${existing}" ]]; then
+            gh issue comment "${existing}" --repo "${GITHUB_REPOSITORY}" --body-file "${body_file}"
+            echo "Commented on existing tracking issue #${existing}"
+          else
+            gh issue create --repo "${GITHUB_REPOSITORY}" \
+              --title "${title}" \
+              --label release-automation \
+              --body-file "${body_file}"
+            echo "Opened new tracking issue for ${WORKFLOW} failure"
+          fi

--- a/scripts/test-probe-aka-ms.ps1
+++ b/scripts/test-probe-aka-ms.ps1
@@ -1,0 +1,60 @@
+# Mirrors the parsing logic in .github/workflows/probe-aka-ms.yml, using
+# curl.exe (bundled with Windows 10+ / Git for Windows) so the byte-for-byte
+# behaviour is comparable to the Ubuntu runner.
+
+$ErrorActionPreference = 'Stop'
+
+$currentUrl  = 'https://aka.ms/discovery/download/current'
+$previousUrl = 'https://aka.ms/discovery/download/previous'
+
+function Resolve-AkaTarget {
+    param([Parameter(Mandatory)][string] $Url)
+    $target = & curl.exe -sI -o NUL -w '%header{location}' $Url
+    if ([string]::IsNullOrWhiteSpace($target)) { throw "No Location header on $Url" }
+    $m = [regex]::Match($target, 'Discovery-app-(\d+\.\d+\.\d+)-preview-win-x64\.exe')
+    if (-not $m.Success) { throw "No version match in redirect target: $target" }
+    [pscustomobject]@{ Version = "v$($m.Groups[1].Value)"; Target = $target }
+}
+
+$current  = Resolve-AkaTarget -Url $currentUrl
+$previous = Resolve-AkaTarget -Url $previousUrl
+
+Write-Host "aka.ms current  ->" $current.Version
+Write-Host "                  " $current.Target
+Write-Host "aka.ms previous ->" $previous.Version
+Write-Host "                  " $previous.Target
+
+# README's current version.
+$readme = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot '..\README.md')
+$readmeMatch = [regex]::Match($readme, 'Current release:\s*<strong>(v\d+\.\d+\.\d+)</strong>')
+if (-not $readmeMatch.Success) { throw 'Could not parse "Current release: <strong>vX.Y.Z</strong>" from README.md' }
+$readmeCurrent = $readmeMatch.Groups[1].Value
+Write-Host "README current  ->" $readmeCurrent
+
+# Last-Modified on the previous blob → previous_date.
+$prevLastMod = & curl.exe -sI -o NUL -w '%header{last-modified}' $previous.Target
+Write-Host "previous Last-Modified header ->" $prevLastMod
+if ([string]::IsNullOrWhiteSpace($prevLastMod)) {
+    $prevDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+    Write-Host "previous_date (fallback: today UTC) ->" $prevDate
+} else {
+    $prevDate = ([datetimeoffset]::Parse($prevLastMod)).ToUniversalTime().ToString('yyyy-MM-dd')
+    Write-Host "previous_date ->" $prevDate
+}
+
+# Decision matrix identical to the workflow.
+if ($current.Version -eq $readmeCurrent) {
+    Write-Host ""
+    Write-Host "DECISION: no-op (README already at $readmeCurrent)"
+    exit 0
+}
+if ($current.Version -eq $previous.Version) {
+    Write-Host ""
+    Write-Host "DECISION: defer (aka.ms current == previous == $($current.Version))"
+    exit 0
+}
+Write-Host ""
+Write-Host "DECISION: would dispatch refresh-current.yml with:"
+Write-Host "  version          = $($current.Version)"
+Write-Host "  previous_version = $($previous.Version)"
+Write-Host "  previous_date    = $prevDate"

--- a/scripts/test-refresh-current-readme.ps1
+++ b/scripts/test-refresh-current-readme.ps1
@@ -1,0 +1,87 @@
+# Mirrors the Python regex substitutions inside .github/workflows/refresh-current.yml
+# (the "Patch README.md" step). Runs against a copy of the real README so you can
+# see exactly what the workflow's PR would look like — without touching the real file.
+#
+# Usage:
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-refresh-current-readme.ps1
+#   pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/test-refresh-current-readme.ps1 `
+#        -NewVersion v0.15.13 -PreviousVersion v0.15.12 -PreviousDate 2026-08-28
+
+param(
+    [string] $NewVersion      = 'v0.15.13',
+    [string] $PreviousVersion = 'v0.15.12',
+    [string] $PreviousDate    = '2026-08-28'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$readme   = Join-Path $repoRoot 'README.md'
+if (-not (Test-Path $readme)) { throw "README.md not found at $readme" }
+
+$prevBare = $PreviousVersion.TrimStart('v')
+$original = Get-Content -Raw -LiteralPath $readme
+
+# 1. Header "Current release: <strong>vX.Y.Z</strong>"
+$headerPattern = '(Current release:\s*<strong>)v\d+\.\d+\.\d+(</strong>)'
+if ([regex]::Matches($original, $headerPattern).Count -ne 1) {
+    throw "Header regex did not match exactly once in README.md"
+}
+$patched = [regex]::Replace($original, $headerPattern, "`${1}$NewVersion`${2}", 1)
+
+# 2. Previous rows — Windows x64 and Windows Arm64
+function Update-PreviousRow {
+    param(
+        [string] $Text,
+        [string] $Arch  # 'x64' or 'Arm64'
+    )
+    $pat = '\|\s*v\d+\.\d+\.\d+\s*_\(previous\)_\s*\|\s*\d{4}-\d{2}-\d{2}\s*\|\s*Windows\s+' `
+         + [regex]::Escape($Arch) `
+         + '\s*\|\s*\[`Discovery-app-\d+\.\d+\.\d+-preview-win-([A-Za-z0-9]+)\.exe`\]' `
+         + '\((https://aka\.ms/discovery/download/[^)]+)\)\s*\|'
+    $rx  = [regex]::new($pat)
+    $ms  = $rx.Matches($Text)
+    if ($ms.Count -ne 1) {
+        throw "Previous-row regex for Windows $Arch matched $($ms.Count) times (expected 1)"
+    }
+    return $rx.Replace($Text, {
+        param($m)
+        $archSuffix = $m.Groups[1].Value
+        $url        = $m.Groups[2].Value
+        $bt         = [char]0x60  # PowerShell escape-char is backtick; build one literally.
+        "| $PreviousVersion _(previous)_ | $PreviousDate | Windows $Arch | [${bt}Discovery-app-$prevBare-preview-win-$archSuffix.exe${bt}]($url) |"
+    }, 1)
+}
+
+$patched = Update-PreviousRow -Text $patched -Arch 'x64'
+$patched = Update-PreviousRow -Text $patched -Arch 'Arm64'
+
+if ($patched -eq $original) { throw "No changes produced; the inputs match the current README state." }
+
+# Diff view.
+$tempOriginal = [System.IO.Path]::GetTempFileName()
+$tempPatched  = [System.IO.Path]::GetTempFileName()
+try {
+    Set-Content -LiteralPath $tempOriginal -Value $original -NoNewline
+    Set-Content -LiteralPath $tempPatched  -Value $patched  -NoNewline
+
+    $git = Get-Command git -ErrorAction SilentlyContinue
+    if ($null -ne $git) {
+        Write-Host "----- diff (unified) -----"
+        & git --no-pager diff --no-index --color=never -- $tempOriginal $tempPatched
+        Write-Host "----- end diff -----"
+    } else {
+        Write-Host "----- old header -----"
+        Select-String -InputObject $original -Pattern 'Current release.*<strong>v[^<]+</strong>' | ForEach-Object { $_.Matches[0].Value }
+        Write-Host "----- new header -----"
+        Select-String -InputObject $patched  -Pattern 'Current release.*<strong>v[^<]+</strong>' | ForEach-Object { $_.Matches[0].Value }
+    }
+} finally {
+    Remove-Item $tempOriginal, $tempPatched -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "OK: patcher would rewrite README.md as shown above."
+Write-Host "    NewVersion      = $NewVersion"
+Write-Host "    PreviousVersion = $PreviousVersion"
+Write-Host "    PreviousDate    = $PreviousDate"


### PR DESCRIPTION
Automating checking for release versions on README and updating the Release widget so it doesn't appear stale.

We don't actually create a release tag `current`, it's a floating tag since we aren't building and previously required some manual steps.  This pipeline will check the release aka.ms for updates and then make the changes, update the current tag and open a PR for human review before updating.


