### PR TITLE
Add SandboxAQ Foundry Model agent

### DIFF
--- a/agents/sandboxaq/README.md
+++ b/agents/sandboxaq/README.md
@@ -1,0 +1,28 @@
+# SandboxAQ Foundry Model Agent
+
+This agent invokes a SandboxAQ model that your organization has subscribed to
+through Azure AI Foundry. It uses a Discovery-managed tool to call the
+OpenAI-compatible Foundry chat-completions endpoint.
+
+## Configuration
+
+Configure these values on the deployed tool; do not commit them to the catalog:
+
+| Environment variable | Required | Description |
+|---|---:|---|
+| `FOUNDRY_ENDPOINT` | Yes | Azure AI Foundry endpoint, including the `/openai` API base |
+| `FOUNDRY_API_KEY` | Yes | Secret for the subscribed deployment |
+| `FOUNDRY_DEPLOYMENT` | Yes | SandboxAQ model deployment name |
+| `FOUNDRY_API_VERSION` | No | API version; defaults to `2024-10-21` |
+
+The endpoint must be reachable from the Discovery tool container. Use the
+Foundry deployment's supported API version and authentication method if it
+differs from this default.
+
+## Example requests
+
+- "Run the SandboxAQ model on this prompt and return the result as JSON."
+- "Summarize this HR policy using the subscribed SandboxAQ deployment."
+
+For sensitive HR data, apply your organization's privacy, access-control, and
+human-review requirements. This agent does not make employment decisions.

--- a/agents/sandboxaq/README.md
+++ b/agents/sandboxaq/README.md
@@ -1,22 +1,126 @@
-# SandboxAQ Foundry Model Agent
+# SandboxAQ Foundry Model Agent Deployment Guide
+
+This guide provides step-by-step instructions for deploying the SandboxAQ
+Foundry Model tool and its associated agent to the Microsoft Discovery
+platform.
+
+## Overview
 
 This agent invokes a SandboxAQ model that your organization has subscribed to
-through Azure AI Foundry. It uses a Discovery-managed tool to call the
-OpenAI-compatible Foundry chat-completions endpoint.
+through Azure AI Foundry, calling the OpenAI-compatible chat-completions
+endpoint from a Discovery-managed tool container. This deployment includes:
 
-## How it works
+- **Dockerfile**: Used for creation of the SandboxAQ model tool container image
+- **Tool Definition**: Configuration for the `sandboxaq-model` tool
+- **Agent Definition**: AI agent configuration for the SandboxAQ agent
+
+## Prerequisites
+
+Before starting the deployment, ensure you have:
+
+1. Access to Microsoft Discovery platform
+2. An active SandboxAQ model subscription deployed in Azure AI Foundry
+3. Azure Container Registry (ACR) with appropriate permissions
+4. Docker installed locally for image building
+5. Azure CLI or PowerShell for resource management
+
+## Build Docker Image
+
+### Step 1: Build and Publish Docker Image
+
+1. **Build the image** from this tool directory:
+
+   ```bash
+   docker build -t sandboxaq-model:latest .
+   ```
+
+2. **Tag the image** for your Azure Container Registry:
+
+   ```bash
+   docker tag sandboxaq-model:latest mycontainerregistry.azurecr.io/sandboxaq-model:latest
+   ```
+
+   > Replace `mycontainerregistry` with your actual ACR name
+
+3. **Login to Azure Container Registry**:
+
+   ```bash
+   az acr login --name mycontainerregistry
+   ```
+
+4. **Push the image** to your container registry:
+
+   ```bash
+   docker push mycontainerregistry.azurecr.io/sandboxaq-model:latest
+   ```
+
+## File Structure
+
+```text
+sandboxaq/
+├── agent.yaml                          # Agent configuration (YAML)
+├── metadata.yaml                       # Catalog metadata
+├── tools/
+│   └── sandboxaq-model/
+│       ├── Dockerfile                  # Container image definition
+│       ├── tool.yaml                   # Tool configuration (YAML)
+│       └── sandboxaq_utils.py          # Foundry client helper module
+└── README.md                           # This deployment guide
+```
+
+## Key Configuration Details
+
+### Agent Capabilities
+
+The SandboxAQ agent provides:
+
+- **Model Invocation**: Sends prompts to the subscribed SandboxAQ deployment
+- **Structured Output**: Preserves JSON returned by the endpoint and writes
+  results to `/output/final_results.json`
+- **Sensitive-Data Handling**: Applies access, privacy, and human-review
+  guidance when working with HR or other confidential business data
+
+## Usage
+
+### Basic Queries
+
+| Prompt | Description |
+|--------|-------------|
+| "Run the SandboxAQ model on this prompt and return the result as JSON." | Direct invocation |
+| "Summarize this HR policy using the subscribed SandboxAQ deployment." | Summarization |
+| "Ask the SandboxAQ model to classify these support tickets." | Classification |
+
+### Advanced Queries
+
+| Prompt | Description |
+|--------|-------------|
+| "Run this prompt at temperature 0.7 and cap the output at 1000 tokens." | Tuned sampling parameters |
+| "Use a system prompt of 'You are a concise policy analyst' for this request." | Custom system instruction |
+| "Invoke the model on each of these five prompts and collect the results." | Batch invocation in one script |
+
+## Architecture
+
+This agent operates as a `kind: prompt` agent within Discovery Studio.
+
+    User Input → SandboxAQ Agent (LLM) → sandboxaq-model Tool (Container) → Azure AI Foundry → Results
+
+- **Model:** Configured via the `{{CHAT-MODEL}}` parameter at deploy time
+- **Tool:** `sandboxaq-model` container exposing a `python3` code environment
 
 The tool exposes a Python code environment rather than a fixed action. The
 agent writes a script that imports `sandboxaq_utils` and calls
 `invoke_model(prompt, system_prompt=..., temperature=..., max_tokens=...)`,
 which returns a dict with `model`, `content`, `usage`, and `raw_response`.
-Results are written to `/output/final_results.json`.
 
 Prompts therefore travel as Python string literals and are never interpolated
 into a shell command, so text containing apostrophes, double quotes, `$`, or
-newlines is passed through to the deployment unmodified.
+newlines reaches the deployment unmodified.
 
 ## Configuration
+
+| Parameter | Description | Example |
+|---|---|---|
+| `{{CHAT-MODEL}}` | Azure AI Foundry model deployment name for the agent | `gpt-4o` |
 
 Configure these values on the deployed tool; do not commit them to the catalog:
 
@@ -31,10 +135,36 @@ The endpoint must be reachable from the Discovery tool container. Use the
 Foundry deployment's supported API version and authentication method if it
 differs from this default.
 
-## Example requests
+## Support
 
-- "Run the SandboxAQ model on this prompt and return the result as JSON."
-- "Summarize this HR policy using the subscribed SandboxAQ deployment."
+For issues or questions with this agent, contact SandboxAQ:
+<https://www.sandboxaq.com/contact>
 
-For sensitive HR data, apply your organization's privacy, access-control, and
-human-review requirements. This agent does not make employment decisions.
+SandboxAQ contact: support@sandboxaq.com
+
+For platform issues, open a GitHub issue:
+<https://github.com/microsoft/discovery/issues>
+
+## Tools
+
+| Tool | Path | Description |
+|---|---|---|
+| `sandboxaq-model` | `tools/sandboxaq-model/` | Invokes a subscribed SandboxAQ model through its Azure AI Foundry OpenAI-compatible chat-completions endpoint. |
+
+## Known Limitations
+
+- Requires an existing SandboxAQ subscription in Azure AI Foundry; the agent
+  cannot provision or discover deployments on your behalf.
+- Supports the chat-completions API surface only. Embeddings, batch, and
+  streaming endpoints are not exposed.
+- Credentials are supplied as environment variables on the deployed tool, so
+  rotating a key requires updating the tool configuration.
+- For sensitive HR data, apply your organization's privacy, access-control,
+  and human-review requirements. This agent does not make employment
+  decisions.
+
+## Contributing
+
+This project welcomes contributions and suggestions. Please see the
+repository's top-level [CONTRIBUTING guidelines](https://github.com/microsoft/discovery/blob/main/CONTRIBUTING.md)
+for details on how to contribute.

--- a/agents/sandboxaq/README.md
+++ b/agents/sandboxaq/README.md
@@ -4,6 +4,18 @@ This agent invokes a SandboxAQ model that your organization has subscribed to
 through Azure AI Foundry. It uses a Discovery-managed tool to call the
 OpenAI-compatible Foundry chat-completions endpoint.
 
+## How it works
+
+The tool exposes a Python code environment rather than a fixed action. The
+agent writes a script that imports `sandboxaq_utils` and calls
+`invoke_model(prompt, system_prompt=..., temperature=..., max_tokens=...)`,
+which returns a dict with `model`, `content`, `usage`, and `raw_response`.
+Results are written to `/output/final_results.json`.
+
+Prompts therefore travel as Python string literals and are never interpolated
+into a shell command, so text containing apostrophes, double quotes, `$`, or
+newlines is passed through to the deployment unmodified.
+
 ## Configuration
 
 Configure these values on the deployed tool; do not commit them to the catalog:

--- a/agents/sandboxaq/agent.yaml
+++ b/agents/sandboxaq/agent.yaml
@@ -7,6 +7,7 @@ model:
   id: '{{CHAT-MODEL}}'
   options:
     temperature: 0
+    topP: 0
     maxOutputTokens: 4096
 instructions: |-
   You are the SandboxAQ Foundry Model Agent. You reach the subscribed

--- a/agents/sandboxaq/agent.yaml
+++ b/agents/sandboxaq/agent.yaml
@@ -1,0 +1,36 @@
+kind: prompt
+name: sandboxaq
+displayName: SandboxAQ Foundry Model Agent
+description: >
+  Invokes subscribed SandboxAQ models through an Azure AI Foundry endpoint.
+model:
+  id: '{{CHAT-MODEL}}'
+  options:
+    temperature: 0
+    maxOutputTokens: 4096
+instructions: |-
+  You are the SandboxAQ Foundry Model Agent.
+
+  Use the SandboxAQ model endpoint through the `invoke_model` tool when the
+  user asks for model inference. Do not claim that a model was invoked unless
+  the tool returns a successful response.
+
+  Keep user inputs and model outputs clearly separated. Preserve structured
+  output when the endpoint returns JSON. Never expose endpoint URLs, API keys,
+  authorization headers, or other deployment secrets.
+
+  For HR or other sensitive business data:
+  - Follow the user's organization's access and data-handling policies.
+  - Do not infer protected attributes or make employment decisions.
+  - State when the model response is uncertain or requires human review.
+  - Return only the minimum sensitive information needed for the request.
+
+  If the request is missing the information required by the endpoint, ask one
+  focused clarifying question.
+discoveryExtensions:
+  humanInTheLoop: Disabled
+  tools:
+    - toolId: '{{SANDBOAQ_MODEL_TOOL_ID}}'
+      confirmation: Disabled
+  disableDataHandlingTools: false
+  disableDiscoveryInjectedTools: false

--- a/agents/sandboxaq/agent.yaml
+++ b/agents/sandboxaq/agent.yaml
@@ -9,28 +9,66 @@ model:
     temperature: 0
     maxOutputTokens: 4096
 instructions: |-
-  You are the SandboxAQ Foundry Model Agent.
+  You are the SandboxAQ Foundry Model Agent. You reach the subscribed
+  SandboxAQ deployment by writing Python scripts that run in the tool's code
+  environment.
 
-  Use the SandboxAQ model endpoint through the `invoke_model` tool when the
-  user asks for model inference. Do not claim that a model was invoked unless
-  the tool returns a successful response.
+  # INSTALLED PYTHON PACKAGES
+  `requests`, `json` (stdlib), and `sandboxaq_utils` (custom module).
+  **NOT available:** pandas, numpy, rdkit, matplotlib. Do NOT import these.
 
-  Keep user inputs and model outputs clearly separated. Preserve structured
-  output when the endpoint returns JSON. Never expose endpoint URLs, API keys,
-  authorization headers, or other deployment secrets.
+  **ALWAYS use `from sandboxaq_utils import invoke_model`** -- this is the
+  ONLY supported way to call the deployment. Never build the request URL,
+  headers, or credential yourself, and never invoke the model through a shell
+  command; passing prompt text through a shell corrupts any prompt containing
+  quotes or `$`.
+
+  ## CRITICAL RULES
+
+  1. Put the prompt in a Python variable, not in a shell command. Triple-quoted
+     string literals handle apostrophes, quotes, and newlines correctly.
+  2. Write results to `/output/final_results.json` with `save_json()`.
+  3. Do not claim a model was invoked unless the script completed and returned
+     a response.
+  4. Keep user inputs and model outputs clearly separated in your report.
+     Preserve structured output when the endpoint returns JSON.
+  5. Never expose endpoint URLs, API keys, authorization headers, or other
+     deployment secrets -- not in scripts, logs, or your reply.
+  6. If the request is missing information the endpoint requires, ask one
+     focused clarifying question before running anything.
+
+  ### Script template
+
+  ```python
+  from sandboxaq_utils import invoke_model, save_json
+
+  prompt = """Summarize the attached policy in five bullet points."""
+
+  result = invoke_model(
+      prompt,
+      system_prompt="You are a concise policy analyst.",
+      temperature=0,
+      max_tokens=4096,
+  )
+
+  print(result["content"])
+  save_json(result, "/output/final_results.json")
+  ```
+
+  `invoke_model` returns a dict with `model`, `content`, `usage`, and
+  `raw_response`. It raises `RuntimeError` when the deployment is not
+  configured and `requests.RequestException` on HTTP failures -- report those
+  errors verbatim rather than retrying blindly.
 
   For HR or other sensitive business data:
   - Follow the user's organization's access and data-handling policies.
   - Do not infer protected attributes or make employment decisions.
   - State when the model response is uncertain or requires human review.
   - Return only the minimum sensitive information needed for the request.
-
-  If the request is missing the information required by the endpoint, ask one
-  focused clarifying question.
 discoveryExtensions:
   humanInTheLoop: Disabled
   tools:
-    - toolId: '{{SANDBOAQ_MODEL_TOOL_ID}}'
+    - toolId: '{{sandboxaqModelToolId}}'
       confirmation: Disabled
   disableDataHandlingTools: false
   disableDiscoveryInjectedTools: false

--- a/agents/sandboxaq/metadata.yaml
+++ b/agents/sandboxaq/metadata.yaml
@@ -1,0 +1,17 @@
+name: sandboxaq
+type: agent
+version: 1.0.0
+associated_tools:
+  - agents/sandboxaq/tools/sandboxaq-model
+publisher:
+  name: SandboxAQ
+  contact: support@sandboxaq.com
+  support_url: https://www.sandboxaq.com/contact
+  party: 3p
+description: >
+  Invokes SandboxAQ models subscribed through Azure AI Foundry for secure,
+  structured inference workflows.
+tags:
+  - sandboxaq
+  - foundry
+  - model-inference

--- a/agents/sandboxaq/tools/sandboxaq-model/Dockerfile
+++ b/agents/sandboxaq/tools/sandboxaq-model/Dockerfile
@@ -1,11 +1,21 @@
 FROM mcr.microsoft.com/azurelinux/base/python:3.12
 
 WORKDIR /app
+
+# System update + TLS certificates (MUST be first RUN for layer sharing)
 RUN tdnf -y update && \
     tdnf -y install ca-certificates && \
     update-ca-trust && \
     tdnf clean all
 RUN pip3 install --no-cache-dir requests
 
-COPY run_action.py /app/run_action.py
-ENTRYPOINT ["python3", "/app/run_action.py"]
+# Create working directories
+RUN mkdir -p /input /output /workdir
+
+# /app: safe from volume mounts, reachable via PYTHONPATH
+COPY sandboxaq_utils.py /app/
+
+WORKDIR /workdir
+ENV PYTHONPATH="/app"
+
+CMD ["/bin/bash"]

--- a/agents/sandboxaq/tools/sandboxaq-model/Dockerfile
+++ b/agents/sandboxaq/tools/sandboxaq-model/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/azurelinux/base/python:3.12
+
+WORKDIR /app
+RUN tdnf -y update && \
+    tdnf -y install ca-certificates && \
+    update-ca-trust && \
+    tdnf clean all
+RUN pip3 install --no-cache-dir requests
+
+COPY run_action.py /app/run_action.py
+ENTRYPOINT ["python3", "/app/run_action.py"]

--- a/agents/sandboxaq/tools/sandboxaq-model/run_action.py
+++ b/agents/sandboxaq/tools/sandboxaq-model/run_action.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+import os
+import sys
+
+import requests
+
+
+def required_env(name):
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Required environment variable is not set: {name}")
+    return value
+
+
+def invoke_model(prompt, system_prompt, temperature, max_tokens):
+    endpoint = required_env("FOUNDRY_ENDPOINT").rstrip("/")
+    deployment = required_env("FOUNDRY_DEPLOYMENT")
+    api_key = required_env("FOUNDRY_API_KEY")
+    api_version = os.environ.get("FOUNDRY_API_VERSION", "2024-10-21")
+    url = (
+        f"{endpoint}/deployments/{deployment}/chat/completions"
+        f"?api-version={api_version}"
+    )
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+    response = requests.post(
+        url,
+        headers={"api-key": api_key, "Content-Type": "application/json"},
+        json={
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        },
+        timeout=300,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    choices = payload.get("choices")
+    if not choices:
+        raise RuntimeError("Foundry response did not contain any choices")
+    return {
+        "model": payload.get("model", deployment),
+        "content": choices[0].get("message", {}).get("content", ""),
+        "usage": payload.get("usage"),
+        "raw_response": payload,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--action", required=True)
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--system", default="")
+    parser.add_argument("--temperature", default="0")
+    parser.add_argument("--max-tokens", default="4096")
+    args = parser.parse_args()
+    if args.action != "invoke_model":
+        raise ValueError(f"Unsupported action: {args.action}")
+    result = invoke_model(
+        args.prompt,
+        args.system,
+        float(args.temperature),
+        int(args.max_tokens),
+    )
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, ValueError, requests.RequestException) as error:
+        print(json.dumps({"error": str(error)}), file=sys.stderr)
+        sys.exit(1)

--- a/agents/sandboxaq/tools/sandboxaq-model/sandboxaq_utils.py
+++ b/agents/sandboxaq/tools/sandboxaq-model/sandboxaq_utils.py
@@ -1,9 +1,21 @@
-import argparse
+"""Helpers for calling a subscribed SandboxAQ model through Azure AI Foundry.
+
+Agent scripts import from this module rather than shelling out, so prompt text
+is never interpreted by a shell:
+
+    from sandboxaq_utils import invoke_model, save_json
+
+    result = invoke_model("Summarize this policy")
+    save_json(result, "/output/final_results.json")
+"""
+
 import json
 import os
-import sys
 
 import requests
+
+DEFAULT_API_VERSION = "2024-10-21"
+DEFAULT_TIMEOUT_SECONDS = 300
 
 
 def required_env(name):
@@ -13,11 +25,23 @@ def required_env(name):
     return value
 
 
-def invoke_model(prompt, system_prompt, temperature, max_tokens):
+def invoke_model(
+    prompt,
+    system_prompt="",
+    temperature=0,
+    max_tokens=4096,
+    timeout=DEFAULT_TIMEOUT_SECONDS,
+):
+    """Send a prompt to the configured SandboxAQ deployment.
+
+    Returns a dict with `model`, `content`, `usage`, and `raw_response`.
+    Raises RuntimeError if the deployment is not configured or returns no
+    choices, and requests.RequestException on transport/HTTP failures.
+    """
     endpoint = required_env("FOUNDRY_ENDPOINT").rstrip("/")
     deployment = required_env("FOUNDRY_DEPLOYMENT")
     api_key = required_env("FOUNDRY_API_KEY")
-    api_version = os.environ.get("FOUNDRY_API_VERSION", "2024-10-21")
+    api_version = os.environ.get("FOUNDRY_API_VERSION", DEFAULT_API_VERSION)
     url = (
         f"{endpoint}/deployments/{deployment}/chat/completions"
         f"?api-version={api_version}"
@@ -34,7 +58,7 @@ def invoke_model(prompt, system_prompt, temperature, max_tokens):
             "temperature": temperature,
             "max_tokens": max_tokens,
         },
-        timeout=300,
+        timeout=timeout,
     )
     response.raise_for_status()
     payload = response.json()
@@ -49,28 +73,11 @@ def invoke_model(prompt, system_prompt, temperature, max_tokens):
     }
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--action", required=True)
-    parser.add_argument("--prompt", required=True)
-    parser.add_argument("--system", default="")
-    parser.add_argument("--temperature", default="0")
-    parser.add_argument("--max-tokens", default="4096")
-    args = parser.parse_args()
-    if args.action != "invoke_model":
-        raise ValueError(f"Unsupported action: {args.action}")
-    result = invoke_model(
-        args.prompt,
-        args.system,
-        float(args.temperature),
-        int(args.max_tokens),
-    )
-    print(json.dumps(result))
-
-
-if __name__ == "__main__":
-    try:
-        main()
-    except (RuntimeError, ValueError, requests.RequestException) as error:
-        print(json.dumps({"error": str(error)}), file=sys.stderr)
-        sys.exit(1)
+def save_json(data, path):
+    """Write `data` to `path` as UTF-8 JSON, creating parent directories."""
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, ensure_ascii=False)
+    return path

--- a/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
+++ b/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
@@ -23,28 +23,12 @@ infra:
         ram: "4Gi"
         storage: "16Gi"
         gpu: 0
-actions:
-  - name: invoke_model
+code_environments:
+  - language: python3
+    command: "python3 -u \"/{{scriptName}}\""
     description: >
-      Send a prompt to the configured SandboxAQ Azure AI Foundry deployment.
-      The endpoint, deployment name, and credential are supplied as runtime
-      environment variables.
+      Python code environment on the SandboxAQ model container image. Scripts
+      import `sandboxaq_utils` to reach the configured Azure AI Foundry
+      deployment; the endpoint, deployment name, and credential are supplied
+      as runtime environment variables.
     infra_node: worker
-    command: "python3 /app/run_action.py --action invoke_model --prompt '{{prompt}}' --system '{{system_prompt}}' --temperature '{{temperature}}' --max-tokens '{{max_tokens}}'"
-    input_schema:
-      type: object
-      properties:
-        prompt:
-          type: string
-          description: User prompt to send to the SandboxAQ model.
-        system_prompt:
-          type: string
-          description: Optional system instruction for this invocation.
-        temperature:
-          type: number
-          description: Sampling temperature. Defaults to 0.
-        max_tokens:
-          type: integer
-          description: Maximum completion tokens. Defaults to 4096.
-      required:
-        - prompt

--- a/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
+++ b/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
@@ -9,20 +9,23 @@ infra:
   - name: worker
     infra_type: container
     image:
-      acr: "{name}/sandboxaq-model:latest"
+      acr: "{name}.azurecr.io/sandboxaq-model:latest"
     compute:
-      pool_type: static
-      pool_size: 1
       min_resources:
         cpu: 1
-        ram: "2Gi"
-        storage: "8Gi"
+        ram: 4Gi
+        storage: 8Gi
         gpu: 0
       max_resources:
         cpu: 2
-        ram: "4Gi"
-        storage: "16Gi"
+        ram: 8Gi
+        storage: 32Gi
         gpu: 0
+      infiniband: false
+      recommended_sku:
+        - Standard_D4s_v6
+      pool_type: static
+      pool_size: 1
 code_environments:
   - language: python3
     command: "python3 -u \"/{{scriptName}}\""

--- a/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
+++ b/agents/sandboxaq/tools/sandboxaq-model/tool.yaml
@@ -1,0 +1,50 @@
+name: sandboxaq-model
+description: >
+  Invokes a subscribed SandboxAQ model through its Azure AI Foundry
+  OpenAI-compatible chat-completions endpoint.
+version: 1.0.0
+license: MIT
+category: "Model Inference"
+infra:
+  - name: worker
+    infra_type: container
+    image:
+      acr: "{name}/sandboxaq-model:latest"
+    compute:
+      pool_type: static
+      pool_size: 1
+      min_resources:
+        cpu: 1
+        ram: "2Gi"
+        storage: "8Gi"
+        gpu: 0
+      max_resources:
+        cpu: 2
+        ram: "4Gi"
+        storage: "16Gi"
+        gpu: 0
+actions:
+  - name: invoke_model
+    description: >
+      Send a prompt to the configured SandboxAQ Azure AI Foundry deployment.
+      The endpoint, deployment name, and credential are supplied as runtime
+      environment variables.
+    infra_node: worker
+    command: "python3 /app/run_action.py --action invoke_model --prompt '{{prompt}}' --system '{{system_prompt}}' --temperature '{{temperature}}' --max-tokens '{{max_tokens}}'"
+    input_schema:
+      type: object
+      properties:
+        prompt:
+          type: string
+          description: User prompt to send to the SandboxAQ model.
+        system_prompt:
+          type: string
+          description: Optional system instruction for this invocation.
+        temperature:
+          type: number
+          description: Sampling temperature. Defaults to 0.
+        max_tokens:
+          type: integer
+          description: Maximum completion tokens. Defaults to 4096.
+      required:
+        - prompt


### PR DESCRIPTION
## Summary

Adds a new third-party catalog agent, `sandboxaq`, that invokes SandboxAQ models subscribed through an Azure AI Foundry OpenAI-compatible chat-completions endpoint.

## What's included

- `agents/sandboxaq/agent.yaml` — prompt agent definition, binds the `sandboxaq-model` tool
- `agents/sandboxaq/metadata.yaml` — publisher metadata (`party: 3p`, SandboxAQ), tags, associated tools
- `agents/sandboxaq/README.md` — configuration and usage guide
- `agents/sandboxaq/tools/sandboxaq-model/` — container tool (Dockerfile on `mcr.microsoft.com/azurelinux/base/python:3.12`, `tool.yaml`, `run_action.py`)

## Configuration

The tool reads its endpoint and credential from runtime environment variables — no secrets are committed to the catalog:

| Variable | Required | Purpose |
|---|---:|---|
| `FOUNDRY_ENDPOINT` | Yes | Foundry endpoint including the `/openai` API base |
| `FOUNDRY_API_KEY` | Yes | Secret for the subscribed deployment |
| `FOUNDRY_DEPLOYMENT` | Yes | SandboxAQ model deployment name |
| `FOUNDRY_API_VERSION` | No | Defaults to `2024-10-21` |

## Notes

The agent's instructions explicitly prohibit exposing endpoint URLs, API keys, and authorization headers, and include data-handling guidance for sensitive business data (no inference of protected attributes, no employment decisions, flag responses needing human review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)